### PR TITLE
Define contribution process

### DIFF
--- a/docs/intro_tutorial.md
+++ b/docs/intro_tutorial.md
@@ -1,3 +1,22 @@
 # Introduction Tutorial
 
+Welcome to Pangeo Forge. This tutorial will guide you through producing your first analysis-ready, cloud-optimized (ARCO) dataset.
+
+To create your ARCO dataset, you'll need to create a new recipe.
+
+### Overview
+
+1. [fork](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) the <https://github.com/pangeo-forge/staged-recipes> GitHub repository
+2. Develop the recipe (see below)
+3. Submit the new recipe as a pull request
+
+At this point the pangeo-forge maintainers (and [a host of bots](https://github.com/pangeo-bot)) will verify that your recipe is shipshape and ready for inclusion in pangeo-forge.
+See [](#maintaining) for more on what happens next.
+
+### Developing a Recipe
+
+TODO
+
+### Maintaining a Recipe
+
 TODO


### PR DESCRIPTION
As noted by @ciaranevans in https://github.com/pangeo-forge/roadmap/issues/9, our docs on contributing a recipe are now obsolete. This PR gets started on updating that page. Before we can really write that, we need to answer a few questions.

- What is the expected structure of a user-contributed recipe? What files does it have to contain? What conventions should they follow?
- Pangeo Forge can be used in a standalone way, separate from the whole cloud infrastructure; you can write and execute your recipe alone and never "contribute" it to the database of recipes. How do we discuss / distinguish this situation in the documentation? 