### PR TITLE
pinned myst-nb to version 0.12.3

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ sphinx
 pydata-sphinx-theme>=0.4.2
 sphinx_book_theme
 myst-parser
-myst-nb
+myst-nb==0.12.3
 sphinx-copybutton
 sphinx-autodoc-typehints
 fsspec

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ sphinx
 pydata-sphinx-theme>=0.4.2
 sphinx_book_theme
 myst-parser
-myst-nb==0.12.3
+myst-nb>=0.12.3
 sphinx-copybutton
 sphinx-autodoc-typehints
 fsspec


### PR DESCRIPTION
Closes #123

I was able to reproduce the build failure using the prexisting `docs/requirements.txt`.

I then noted that, for some reason, `pip` seemed to be installing a rather old version of `myst-nb` by default. After pinning `myst-nb` to its latest release version on PyPI (version 0.12.3), the build succeeded.