### PR TITLE
Prep for 0.3.0 release

### DIFF
--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -1,0 +1,7 @@
+# Development
+
+```{toctree}
+:maxdepth: 1
+
+release_notes
+```

--- a/docs/development/release_notes.md
+++ b/docs/development/release_notes.md
@@ -6,6 +6,7 @@
 
 Many feature enhancements.
 Non-backwards compatible changes to core API.
+Package renamed from `pangeo_forge` to `pangeo_forge_recipes`.
 
 ## v0.2.0 - 2021-04-26
 

--- a/docs/development/release_notes.md
+++ b/docs/development/release_notes.md
@@ -1,0 +1,17 @@
+# Release Notes
+
+## v0.3.1 (Unreleased)
+
+## v0.3.0 - 2021-05-10
+
+Many feature enhancements.
+Non-backwards compatible changes to core API.
+
+## v0.2.0 - 2021-04-26
+
+First release since major Spring 2021 overhaul.
+This release depends on Xarray v0.17.1, which has not yet been released as of the date of this release.
+
+## v0.1.0 - 2020-10-22
+
+First release.

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,5 +52,5 @@ execution
 tutorials/index
 recipe_box
 bakeries
-
+development/index
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ click
 dask
 distributed
 rechunker==0.4.2
-xarray@git+https://github.com/pydata/xarray
+xarray>=0.18.0
 zarr >= 2.6.0
 fsspec[http]


### PR DESCRIPTION
- Adds release notes page to docs
- Updates xarray dep now that 0.18.0 is released