### PR TITLE
Expand doc on target_chunks

### DIFF
--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -64,7 +64,7 @@ class XarrayZarrRecipe(BaseRecipe):
        Must be an integer >= 1.
     :param target_chunks: Desired chunk structure for the targret dataset. This is a dictionary
        mapping dimension names to chunk size. When using a :class:`patterns.FilePattern` with
-       a :class:`patterns.ConcatDim` that specifies ``n_items_per_input``, then you don't need
+       a :class:`patterns.ConcatDim` that specifies ``n_items_per_file``, then you don't need
        to include the concat dim in ``target_chunks``.
     :param target: A location in which to put the dataset. Can also be assigned at run time.
     :param input_cache: A location in which to cache temporary data.

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -62,7 +62,10 @@ class XarrayZarrRecipe(BaseRecipe):
     :param file_pattern: An object which describes the organization of the input files.
     :param inputs_per_chunk: The number of inputs to use in each chunk along the concat dim.
        Must be an integer >= 1.
-    :param target_chunks: Desired chunk structure for the targret dataset.
+    :param target_chunks: Desired chunk structure for the targret dataset. This is a dictionary
+       mapping dimension names to chunk size. When using a :class:`patterns.FilePattern` with
+       a :class:`patterns.ConcatDim` that specifies ``n_items_per_input``, then you don't need
+       to include the concat dim in ``target_chunks``.
     :param target: A location in which to put the dataset. Can also be assigned at run time.
     :param input_cache: A location in which to cache temporary data.
     :param metadata_cache: A location in which to cache metadata for inputs and chunks.


### PR DESCRIPTION
I think this is the correct interpretation. It seems to work for the `prepare_target` stage, and I'll be putting data through soon.