### PR TITLE
Add copy_pruned() method to XarrayZarrRecipe

### DIFF
--- a/pangeo_forge_recipes/patterns.py
+++ b/pangeo_forge_recipes/patterns.py
@@ -2,7 +2,7 @@
 Filename / URL patterns.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from itertools import product
 from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 
@@ -175,10 +175,7 @@ def prune_pattern(fp: FilePattern, nkeep: int = 2) -> FilePattern:
             new_combine_dims.append(cdim)
         elif isinstance(cdim, ConcatDim):
             new_keys = cdim.keys[:nkeep]
-            # this feels like a fragile way to copy a DataClass but it works for now
-            new_cdim = ConcatDim(
-                name=cdim.name, keys=new_keys, nitems_per_file=cdim.nitems_per_file
-            )
+            new_cdim = replace(cdim, keys=new_keys)
             new_combine_dims.append(new_cdim)
         else:  # pragma: no cover
             assert "Should never happen"

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -49,7 +49,7 @@ def test_file_pattern_concat_merge(pickle):
     fp = FilePattern(format_function, merge, concat)
 
     if pickle:
-        # regular pickle doesn't work here because it can't pickle format_funciton
+        # regular pickle doesn't work here because it can't pickle format_function
         from cloudpickle import dumps, loads
 
         fp = loads(dumps(fp))

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,6 +1,12 @@
 import pytest
 
-from pangeo_forge_recipes.patterns import ConcatDim, FilePattern, MergeDim, pattern_from_file_sequence
+from pangeo_forge_recipes.patterns import (
+    ConcatDim,
+    FilePattern,
+    MergeDim,
+    pattern_from_file_sequence,
+    prune_pattern,
+)
 
 
 def test_file_pattern_concat():
@@ -68,3 +74,17 @@ def test_file_pattern_concat_merge(pickle):
         assert fp[key] == fname
         fnames.append(fname)
     assert list(fp.items()) == list(zip(expected_keys, fnames))
+
+
+@pytest.mark.parametrize("nkeep", [1, 2])
+def test_prune(nkeep):
+    concat = ConcatDim(name="time", keys=list(range(3)))
+    merge = MergeDim(name="variable", keys=["foo", "bar"])
+
+    def format_function(time, variable):
+        return f"T_{time}_V_{variable}"
+
+    fp = FilePattern(format_function, merge, concat)
+    fp_pruned = prune_pattern(fp, nkeep=nkeep)
+    assert fp_pruned.dims == {"variable": 2, "time": nkeep}
+    assert len(list(fp_pruned.items())) == 2 * nkeep

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -23,6 +23,21 @@ def test_recipe(recipe_fixture, execute_recipe):
     xr.testing.assert_identical(ds_actual, ds_expected)
 
 
+@pytest.mark.parametrize("recipe_fixture", all_recipes)
+@pytest.mark.parametrize("nkeep", [1, 2])
+def test_prune_recipe(recipe_fixture, execute_recipe, nkeep):
+    """The basic recipe test. Use this as a template for other tests."""
+
+    RecipeClass, file_pattern, kwargs, ds_expected, target = recipe_fixture
+    rec = RecipeClass(file_pattern, **kwargs)
+    rec_pruned = rec.copy_pruned(nkeep=nkeep)
+    assert len(list(rec.iter_inputs())) > len(list(rec_pruned.iter_inputs()))
+    execute_recipe(rec_pruned)
+    ds_pruned = xr.open_zarr(target.get_mapper()).load()
+    nitems_per_input = list(file_pattern.nitems_per_input.values())[0]
+    assert ds_pruned.dims["time"] == nkeep * nitems_per_input
+
+
 @pytest.mark.parametrize("cache_inputs", [True, False])
 @pytest.mark.parametrize("copy_input_to_local_file", [True, False])
 def test_recipe_caching_copying(


### PR DESCRIPTION
### What I changed

This perhaps closes #97 by adding a new method called `copy_pruned` to the `XarrayZarrRecipe` class. The way you use this is

```python
rec = XarrayZarrRecipe(**kwargs)
rec_pruned = rec.copy_pruned()  # much smaller version of the same recipe
```

The way this works is by keeping the first `nkeep` files (default `nkeep=2`) along the the ConcatDim of the recipe. MergeDims, in contrast are not pruned. The thinking here is that we don't want to skip any variables when testing the recipe.

This does not guarantee that the recipe will be smaller than a specific size in MB. It simply naively reduces the number of input files.

### Next Step

If we like this feature, then we can incorporate it into a hypothetical recipe testing mechanism that can be used in our CI (see discussion in https://github.com/pangeo-forge/staged-recipes/pull/28, [ADR5](https://github.com/pangeo-forge/roadmap/blob/master/doc/adr/0005-administrative-commands-for-pr-testing.md))

(Note that this builds on #117, which ideally should be merged first.)

