### PR TITLE
Fix ragged array warning in patterns.py

### DIFF
--- a/pangeo_forge_recipes/patterns.py
+++ b/pangeo_forge_recipes/patterns.py
@@ -73,7 +73,7 @@ class FilePattern:
             kwargs = dict(zip(dim_names, keys))
             fnames.append(format_function(**kwargs))
         shape = [len(cdim.keys) for cdim in combine_dims]
-        fnames_np = np.array(fnames)
+        fnames_np = np.array(fnames, dtype=object)
         fnames_np.shape = tuple(shape)
         # This way of defining coords is incompatible with xarray type annotations.
         # I don't understand why.


### PR DESCRIPTION
In working on https://github.com/pangeo-forge/staged-recipes/pull/26, the following code 

<details>
  <summary>Details</summary>

 ```python
 from itertools import product

 from pangeo_forge_recipes.patterns import MergeDim, ConcatDim, FilePattern
 from pangeo_forge_recipes.recipes import XarrayZarrRecipe

 months = [f"{m:02d}" for m in (2,3,4,8,9,10)]
 concat_months = ConcatDim("months", keys=months)

def gen_url(variables, months, freq="4h", dim="surface"):
    base = (
        "https://data.geomar.de/downloads/20.500.12085/"
        "0e95d316-f1ba-47e3-b667-fc800afafe22/data/"
    )
    input_urls = [
        base + f"INALT60_{freq}_{dim}_{var}_{month}.nc"
        for var, month in product(variables, months)
    ]
    return input_urls

 surf_ocean_merge = MergeDim("variables", keys=["u", "v", "hts"])
 surf_ocean_pattern_4h = FilePattern(gen_url, surf_ocean_merge, concat_months)
 ```

</details>

raised the warning
```
/pangeo-forge-recipes/pangeo_forge_recipes/patterns.py:74: 
VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences 
(which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) 
is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  fnames_np = np.array(fnames)
```
I assume this is because the merge keys `["u", "v", "hts"]` are not of uniform length. 

Re-installing pangeo-forge-recipes from this PR branch resolved the warning.