### PR TITLE
Fix rechunker dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     click
     dask
     distributed
-    rechunker==0.4.2
+    rechunker>=0.4.2
     xarray >=0.18.0
     zarr >= 2.6.0
     fsspec[http]


### PR DESCRIPTION
A [RTD build](https://readthedocs.org/projects/pangeo-forge/builds/13840798/) just failed because of an rechunker dependency problem. Hopefully this fixes.
