### PR TITLE
Pass fsspec_open_kwargs to _get_url_size in storage.py

### DIFF
--- a/pangeo_forge_recipes/storage.py
+++ b/pangeo_forge_recipes/storage.py
@@ -27,7 +27,7 @@ def _get_url_size(fname, **open_kwargs):
 @contextmanager
 def _fsspec_safe_open(fname: str, **kwargs) -> Iterator[OpenFileType]:
     fs, _, paths = fsspec.get_fs_token_paths(
-        fname, mode="rb", **{k: v for k, v in kwargs.items() if k != "mode"}
+        fname, mode="rb", storage_options={k: v for k, v in kwargs.items() if k != "mode"}
     )
     path = paths[0]
     logger.debug(f"_fsspec_safe_open opening {path} with fs {fs}")

--- a/pangeo_forge_recipes/storage.py
+++ b/pangeo_forge_recipes/storage.py
@@ -18,8 +18,8 @@ logger = logging.getLogger(__name__)
 OpenFileType = Any
 
 
-def _get_url_size(fname):
-    with fsspec.open(fname, mode="rb") as of:
+def _get_url_size(fname, **open_kwargs):
+    with fsspec.open(fname, mode="rb", **open_kwargs) as of:
         size = of.size
     return size
 
@@ -150,7 +150,7 @@ class CacheFSSpecTarget(FlatFSSpecTarget):
         logger.info(f"Caching file '{fname}'")
         if self.exists(fname):
             cached_size = self.size(fname)
-            remote_size = _get_url_size(fname)
+            remote_size = _get_url_size(fname, **open_kwargs)
             if cached_size == remote_size:
                 # TODO: add checksumming here
                 logger.info(f"File '{fname}' is already cached")

--- a/pangeo_forge_recipes/storage.py
+++ b/pangeo_forge_recipes/storage.py
@@ -26,7 +26,7 @@ def _get_url_size(fname, **open_kwargs):
 
 @contextmanager
 def _fsspec_safe_open(fname: str, **kwargs) -> Iterator[OpenFileType]:
-    fs, _, paths = fsspec.get_fs_token_paths(fname, mode="rb")
+    fs, _, paths = fsspec.get_fs_token_paths(fname, mode="rb", **kwargs)
     path = paths[0]
     logger.debug(f"_fsspec_safe_open opening {path} with fs {fs}")
     with fs.open(path, mode="rb") as fp:

--- a/pangeo_forge_recipes/storage.py
+++ b/pangeo_forge_recipes/storage.py
@@ -26,7 +26,9 @@ def _get_url_size(fname, **open_kwargs):
 
 @contextmanager
 def _fsspec_safe_open(fname: str, **kwargs) -> Iterator[OpenFileType]:
-    fs, _, paths = fsspec.get_fs_token_paths(fname, mode="rb", **kwargs)
+    fs, _, paths = fsspec.get_fs_token_paths(
+        fname, mode="rb", **{k: v for k, v in kwargs.items() if k != "mode"}
+    )
     path = paths[0]
     logger.debug(f"_fsspec_safe_open opening {path} with fs {fs}")
     with fs.open(path, mode="rb") as fp:


### PR DESCRIPTION
https://github.com/pangeo-forge/staged-recipes/pull/27 is an example of a recipe for which the source file server requires login credentials. During manual execution, these creds can be "tacked on" to the recipe as described in https://github.com/pangeo-forge/staged-recipes/pull/27#issuecomment-848453404.

When attempting to cache source files, however, I noticed that the helper function `_get_url_size` was not getting a handoff of the recipe's `fsspec_open_kwargs`. (Presumably just because this is an edge case which we haven't run into yet.)

<details>
    <summary> Here's the Traceback </summary>

```python
# here, `rec` is a recipe from the staged-recipes PR linked above,
# ... to which creds have been "tacked on" as shown in the PR comment linked above
for input_name in rec.iter_inputs():
    rec.cache_input(input_name)
```
```
pangeo_forge_recipes.recipes.xarray_zarr - INFO - Caching input '(0,)'
pangeo_forge_recipes.storage - INFO - Caching file 'ftp://eftp.ifremer.fr/SWOT/SURF/gigatl1_1h_tides_surf_avg_1_2008-08-01.nc'
---------------------------------------------------------------------------
error_perm                                Traceback (most recent call last)
<ipython-input-12-d14b93ca6904> in <module>
      1 for input_name in rec.iter_inputs():
----> 2     rec.cache_input(input_name)

/srv/conda/envs/notebook/lib/python3.8/site-packages/pangeo_forge_recipes/recipes/xarray_zarr.py in cache_input(self, input_key)
    285             logger.info(f"Caching input '{input_key}'")
    286             fname = self.file_pattern[input_key]
--> 287             self.input_cache.cache_file(fname, **self.fsspec_open_kwargs)
    288 
    289         if self._cache_metadata:

/srv/conda/envs/notebook/lib/python3.8/site-packages/pangeo_forge_recipes/storage.py in cache_file(self, fname, **open_kwargs)
    137         if self.exists(fname):
    138             cached_size = self.size(fname)
--> 139             remote_size = _get_url_size(fname)
    140             if cached_size == remote_size:
    141                 # TODO: add checksumming here

/srv/conda/envs/notebook/lib/python3.8/site-packages/pangeo_forge_recipes/storage.py in _get_url_size(fname)
     20 
     21 def _get_url_size(fname):
---> 22     with fsspec.open(fname, mode="rb") as of:
     23         size = of.size
     24     return size

/srv/conda/envs/notebook/lib/python3.8/site-packages/fsspec/core.py in open(urlpath, mode, compression, encoding, errors, protocol, newline, **kwargs)
    426     ``OpenFile`` object.
    427     """
--> 428     return open_files(
    429         urlpath=[urlpath],
    430         mode=mode,

/srv/conda/envs/notebook/lib/python3.8/site-packages/fsspec/core.py in open_files(urlpath, mode, compression, encoding, errors, name_function, num, protocol, newline, auto_mkdir, expand, **kwargs)
    278     be used as a single context
    279     """
--> 280     fs, fs_token, paths = get_fs_token_paths(
    281         urlpath,
    282         mode,

/srv/conda/envs/notebook/lib/python3.8/site-packages/fsspec/core.py in get_fs_token_paths(urlpath, mode, num, name_function, storage_options, protocol, expand)
    606                 )
    607             update_storage_options(options, storage_options)
--> 608             fs = cls(**options)
    609         else:
    610             protocols = split_protocol(urlpath)[0]

/srv/conda/envs/notebook/lib/python3.8/site-packages/fsspec/spec.py in __call__(cls, *args, **kwargs)
     67             return cls._cache[token]
     68         else:
---> 69             obj = super().__call__(*args, **kwargs)
     70             # Setting _fs_token here causes some static linters to complain.
     71             obj._fs_token_ = token

/srv/conda/envs/notebook/lib/python3.8/site-packages/fsspec/implementations/ftp.py in __init__(self, host, port, username, password, acct, block_size, tempdir, timeout, **kwargs)
     61         else:
     62             self.blocksize = 2 ** 16
---> 63         self._connect()
     64 
     65     def _connect(self):

/srv/conda/envs/notebook/lib/python3.8/site-packages/fsspec/implementations/ftp.py in _connect(self)
     66         self.ftp = FTP(timeout=self.timeout)
     67         self.ftp.connect(self.host, self.port)
---> 68         self.ftp.login(*self.cred)
     69 
     70     @classmethod

/srv/conda/envs/notebook/lib/python3.8/ftplib.py in login(self, user, passwd, acct)
    401         resp = self.sendcmd('USER ' + user)
    402         if resp[0] == '3':
--> 403             resp = self.sendcmd('PASS ' + passwd)
    404         if resp[0] == '3':
    405             resp = self.sendcmd('ACCT ' + acct)

/srv/conda/envs/notebook/lib/python3.8/ftplib.py in sendcmd(self, cmd)
    273         '''Send a command and return the response.'''
    274         self.putcmd(cmd)
--> 275         return self.getresp()
    276 
    277     def voidcmd(self, cmd):

/srv/conda/envs/notebook/lib/python3.8/ftplib.py in getresp(self)
    246             raise error_temp(resp)
    247         if c == '5':
--> 248             raise error_perm(resp)
    249         raise error_proto(resp)
    250 

error_perm: 530 Login incorrect.
```
</details>

Re-installing `pangeo-forge-recipes` from this PR branch resolves this issue and allows caching to proceed unencumbered.

I'm leaving this PR as a draft until I've completed the full manual execution of this recipe, just in case I run into any other similar roadblocks at other execution stages. 
