### PR TITLE
Reset default copy_input_to_local_file=False for XarrayZarrRecipe

### DIFF
--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -93,7 +93,7 @@ class XarrayZarrRecipe(BaseRecipe):
     input_cache: Optional[CacheFSSpecTarget] = None
     metadata_cache: Optional[MetadataTarget] = None
     cache_inputs: bool = True
-    copy_input_to_local_file: bool = True
+    copy_input_to_local_file: bool = False
     consolidate_zarr: bool = True
     xarray_open_kwargs: dict = field(default_factory=dict)
     xarray_concat_kwargs: dict = field(default_factory=dict)


### PR DESCRIPTION
@rabernat set a default of `copy_input_to_local_file=True` in `XarrayZarrRecipe` at commit https://github.com/pangeo-forge/pangeo-forge-recipes/pull/146/commits/e92c5f2344329be7ff38e2ca5c244e488cebf4cf of https://github.com/pangeo-forge/pangeo-forge-recipes/pull/146. This was part of an extensive debugging journey which is (hopefully) complete now, and can therefore be reset.

Resetting this to `copy_input_to_local_file=False` came up as part of our conversation about the questions I outlined in https://github.com/pangeo-forge/pangeo-forge-recipes/issues/154. As it turns out, my (mis)perception of the cost of metadata caching resulted partially from misreading the logs: what I thought was a lot of logging for metadata caching was actually the logging for `copy_input_to_local_file`.