### PR TITLE
Configurable lock timeouts

### DIFF
--- a/pangeo_forge_recipes/utils.py
+++ b/pangeo_forge_recipes/utils.py
@@ -104,7 +104,10 @@ def lock_for_conflicts(conflicts, base_name="pangeo-forge", timeout=None):
         locks = [Lock(f"{base_name}-{c}", global_client) for c in conflicts]
         for lock in locks:
             logger.debug(f"Acquiring lock {lock.name}...")
-            lock.acquire(timeout=timeout)
+            acquired = lock.acquire(timeout=timeout)
+            if not acquired:
+                logger.warning("Failed to acquire lock %s before timeout %s", lock.name, timeout)
+                raise ValueError(f"Failed to acquire lock {lock.name} before timeout {timeout}")
             logger.debug(f"Acquired lock {lock.name}")
     else:
         logger.debug(f"Asked to lock {conflicts} but no Dask client found.")

--- a/pangeo_forge_recipes/utils.py
+++ b/pangeo_forge_recipes/utils.py
@@ -84,7 +84,13 @@ def chunk_bounds_and_conflicts(
 @contextmanager
 # TODO: use a recipe-specific base_name to handle multiple recipes potentially
 # running at the same time
-def lock_for_conflicts(conflicts, base_name="pangeo-forge"):
+def lock_for_conflicts(conflicts, base_name="pangeo-forge", timeout=None):
+    """
+    Parameters
+    ----------
+    timeout : int, optional
+        The time to wait *for each lock*.
+    """
 
     try:
         global_client = get_client()
@@ -98,7 +104,7 @@ def lock_for_conflicts(conflicts, base_name="pangeo-forge"):
         locks = [Lock(f"{base_name}-{c}", global_client) for c in conflicts]
         for lock in locks:
             logger.debug(f"Acquiring lock {lock.name}...")
-            lock.acquire()
+            lock.acquire(timeout=timeout)
             logger.debug(f"Acquired lock {lock.name}")
     else:
         logger.debug(f"Asked to lock {conflicts} but no Dask client found.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,4 +303,5 @@ def execute_recipe(request, dask_cluster):
                 client.close()
                 del client
 
+    execute.param = request.param
     return execute

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -77,3 +77,12 @@ def test_locked_array_writing(shape, zarr_chunks, write_chunks, tmp_target, dask
 
     this_client.close()
     del this_client
+
+
+def test_lock_timeout(dask_cluster):
+    with Client(dask_cluster, set_as_default=True):
+        with lock_for_conflicts(["key"]):
+            with Client(dask_cluster, set_as_default=True):
+                with pytest.raises(ValueError, match="Failed to acquire"):
+                    with lock_for_conflicts(["key"], timeout=1):
+                        pass

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -7,8 +7,6 @@ import xarray as xr
 # need to import this way (rather than use pytest.lazy_fixture) to make it work with dask
 from pytest_lazyfixture import lazy_fixture
 
-from tests.conftest import execute_recipe
-
 all_recipes = [
     lazy_fixture("netCDFtoZarr_sequential_recipe"),
     lazy_fixture("netCDFtoZarr_sequential_multi_variable_recipe"),

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -166,6 +166,9 @@ def test_lock_timeout(netCDFtoZarr_sequential_recipe, execute_recipe):
     with patch("pangeo_forge_recipes.recipes.xarray_zarr.lock_for_conflicts") as p:
         execute_recipe(recipe)
 
-    #
-    if p.call_count:
+    # We can only check that the mock object is called with the right parameters if
+    # the function is called in the same processes as our mock object. We can't
+    # observe anything that happens when the function is executed in subprocess, i.e.
+    # if we're using a Dask executor.
+    if execute_recipe.param in {"manual", "python", "prefect"}:
         assert p.call_args[1]["timeout"] == 1


### PR DESCRIPTION
This allows for setting a timeout on a recipe to control how long it waits to acquire a lock.

xref https://github.com/pangeo-forge/pangeo-forge-azure-bakery/issues/10, where I'm apparently seeing some locking issues.