### PR TITLE
File subsetting

### DIFF
--- a/pangeo_forge_recipes/patterns.py
+++ b/pangeo_forge_recipes/patterns.py
@@ -13,7 +13,7 @@ class SubsetSpec:
     """A data structure that explains how to subset a file in one dimension.
     """
 
-    dim_name: str
+    dim: str
     this_segment: int
     total_segments: int
 
@@ -167,7 +167,7 @@ class FilePattern:
         }
         fname = self.format_function(**format_function_kwargs)
         subset_specs = [
-            SubsetSpec(dim_name=cdim.dim, this_segment=i, total_segments=cdim.subset_factor)
+            SubsetSpec(dim=cdim.dim, this_segment=i, total_segments=cdim.subset_factor)
             for cdim, i in zip(self.combine_dims, indexer)
             if isinstance(cdim, SubsetDim)
         ]

--- a/pangeo_forge_recipes/patterns.py
+++ b/pangeo_forge_recipes/patterns.py
@@ -2,12 +2,10 @@
 Filename / URL patterns.
 """
 
+# import warnings
 from dataclasses import dataclass, field, replace
 from itertools import product
 from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
-
-import numpy as np
-import xarray as xr
 
 
 @dataclass
@@ -50,43 +48,46 @@ Index = Tuple[int, ...]
 CombineDim = Union[MergeDim, ConcatDim]
 
 
+@dataclass
+class SubsetDim:
+    """Adds an layer of iteration to represent subsetting within each file.
+
+    :param name: The name of the dimension we are subsetting over.
+    :param subset_factor: How many pieces to divide each segment into.
+    """
+
+    subset_dim: str  # should match the actual dimension name we are subsetting over
+    subset_factor: int
+
+    @property
+    def name(self):
+        return f"{self.subset_dim}_subset"
+
+    @property
+    def keys(self):
+        return list(range(self.subset_factor))
+
+
+# the type which should be returned by format_function
+OpenSpec = Tuple[str, dict]
+
+
 class FilePattern:
     """Represents an n-dimensional matrix of individual files to be combined
     through a combination of merge and concat operations. Each operation generates
     a new dimension to the matrix.
 
     :param format_function: A function that takes one argument for each
-      combine_op and returns a string representing the filename / url paths.
+      combine_op and returns an open_spec (tuple of fname and open_kwargs)
       Each argument name should correspond to a ``name`` in the ``combine_dims``
       list.
     :param combine_dims: A sequence of either concat or merge dimensions. The outer
       product of the keys is used to generate the full list of file paths.
     """
 
-    @staticmethod
-    def _make_da(format_function, combine_dims) -> xr.DataArray:
-        dim_names = [cdim.name for cdim in combine_dims]
-        fnames = []
-        for keys in product(*[cdim.keys for cdim in combine_dims]):
-            kwargs = dict(zip(dim_names, keys))
-            fnames.append(format_function(**kwargs))
-        shape = [len(cdim.keys) for cdim in combine_dims]
-        fnames_np = np.array(fnames)
-        fnames_np.shape = tuple(shape)
-        # This way of defining coords is incompatible with xarray type annotations.
-        # I don't understand why.
-        coords = {cdim.name: (cdim.name, cdim.keys) for cdim in combine_dims}
-        return xr.DataArray(fnames_np, dims=list(coords), coords=coords)  # type: ignore
-
     def __init__(self, format_function: Callable, *combine_dims: CombineDim):
-        self.__setstate__((format_function, combine_dims))
-
-    def __getstate__(self):
-        return self.format_function, self.combine_dims
-
-    def __setstate__(self, state):
-        self.format_function, self.combine_dims = state
-        self._da = self._make_da(self.format_function, self.combine_dims)
+        self.format_function = format_function
+        self.combine_dims = combine_dims
 
     def __repr__(self):
         return f"<FilePattern {self.dims}>"
@@ -100,7 +101,7 @@ class FilePattern:
     @property
     def shape(self) -> Tuple[int, ...]:
         """Shape of the filename matrix."""
-        return self._da.shape
+        return tuple([len(op.keys) for op in self.combine_dims])
 
     @property
     def merge_dims(self) -> List[str]:
@@ -135,7 +136,12 @@ class FilePattern:
 
     def __getitem__(self, indexer) -> str:
         """Get a filename path for a particular key. """
-        return self._da[indexer].values.item()
+        assert len(indexer) == len(self.combine_dims)
+        format_function_kwargs = {
+            cdim.name: cdim.keys[i] for cdim, i in zip(self.combine_dims, indexer)
+        }
+        fname = self.format_function(**format_function_kwargs)
+        return fname
 
     def __iter__(self) -> Iterator[Index]:
         """Iterate over all keys in the pattern. """

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -122,7 +122,7 @@ def cache_input(
         if input_cache is None:
             raise ValueError("input_cache is not set.")
         logger.info(f"Caching input '{input_key}'")
-        fname, _ = file_pattern[input_key]
+        fname = file_pattern[input_key].fname
         input_cache.cache_file(fname, **fsspec_open_kwargs)
 
     if cache_metadata:
@@ -196,7 +196,7 @@ def open_input(
     delete_input_encoding: bool,
     process_input: Optional[Callable[[xr.Dataset, str], xr.Dataset]],
 ) -> xr.Dataset:
-    fname, input_kwargs = file_pattern[input_key]
+    fname = file_pattern[input_key].fname
     # TODO: handle subsetting
     logger.info(f"Opening input with Xarray {input_key}: '{fname}'")
     cache = input_cache if cache_inputs else None


### PR DESCRIPTION
Closes #93 by allowing us to have many virtual "inputs" per file. This is one possible implementation, and I'm looking for feedback on whether this approach makes sense.

### New Data Structures: `OpenSpec`, `SubsetSpec`

Before this PR, FilePatterns simply mapped input keys to strings, understood to be filenames.

With this PR, we introduce a new data structure called `OpenSpec`

https://github.com/pangeo-forge/pangeo-forge-recipes/blob/e47d49ffbc1d345be1d90846b8484ac4b6426aa4/pangeo_forge_recipes/patterns.py#L26-L32

The `OpenSpec` contains the filename and also potentially many `SubsetSpecs`

https://github.com/pangeo-forge/pangeo-forge-recipes/blob/e47d49ffbc1d345be1d90846b8484ac4b6426aa4/pangeo_forge_recipes/patterns.py#L11-L18

Each `SubsetSpec` tells us how to decimate a file into an arbitrary number of "segments" or pieces (open to changing this terminology) along a specified dimension. Now, when iterating through a FilePattern, we get not just the filename, but also, optionally, these SubsetSpecs.

<details>
  <summary>Example</summary>

```python
from pangeo_forge_recipes import patterns

def format_function(time):
    return f'file_{time}.nc'

concat_dim = patterns.ConcatDim(name="time", keys=[10, 20, 30])
subset_dim = patterns.SubsetDim(dim="time", subset_factor=2)
fp = patterns.FilePattern(format_function, concat_dim, subset_dim)

for key, value in fp.items():
    print(key, value)
```

```
(0, 0) OpenSpec(fname='file_10.nc', subsets=[SubsetSpec(dim='time', this_segment=0, total_segments=2)])
(0, 1) OpenSpec(fname='file_10.nc', subsets=[SubsetSpec(dim='time', this_segment=1, total_segments=2)])
(1, 0) OpenSpec(fname='file_20.nc', subsets=[SubsetSpec(dim='time', this_segment=0, total_segments=2)])
(1, 1) OpenSpec(fname='file_20.nc', subsets=[SubsetSpec(dim='time', this_segment=1, total_segments=2)])
(2, 0) OpenSpec(fname='file_30.nc', subsets=[SubsetSpec(dim='time', this_segment=0, total_segments=2)])
(2, 1) OpenSpec(fname='file_30.nc', subsets=[SubsetSpec(dim='time', this_segment=1, total_segments=2)])
```

</details>

This effectively allows us to break a big file into many small pieces, lazily slicing it to a range determined by the SubsetSpec, and treating these as distinct individual inputs. Here is how the `XarrayZarrRecipe.open_input` handles these SubsetSpecs:

https://github.com/pangeo-forge/pangeo-forge-recipes/blob/e47d49ffbc1d345be1d90846b8484ac4b6426aa4/pangeo_forge_recipes/recipes/xarray_zarr.py#L227-L230

### The Problem: Caching given One-to-Many relationship between actual Files and Inputs

Before, each "input" was an actual physical file. So caching inputs could be performed like

```python
for input in recipe.iter_inputs():
    recipe.cache_input(input)
```

Caching of subsetted files does not make sense. We want to either cache a whole file or not at all. If we run this code now, and simply discard the subset information, we will end up caching each file multiple times. If we just cache on the first iteration of each subset, the cache_metadata step will break.

### Alternative: implement Subsetting at the Chunk Level

Writing this up made me realize I make have made a bad choice in how I implemented this. We should probably be implementing subsetting at the chunk stage, not the input stage. 🤦 

I'm going to make a second try in a new PR.