### PR TITLE
Update to codecov-action@v2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,8 +57,9 @@ jobs:
         shell: bash -l {0}
         run: |
           py.test tests -v --redirect-dask-worker-logs-to-stdout=DEBUG \
-            --cov=pangeo_forge_recipes --cov-config .coveragerc --cov-report term-missing
-          coverage xml
+            --cov=pangeo_forge_recipes --cov-config .coveragerc \
+            --cov-report term-missing \
+            --cov-report xml
       - name: Codecov
         uses: codecov/codecov-action@v2.0.2
         with:


### PR DESCRIPTION
Updated codecov-action to v2 based on [xgcm codecov workflow](https://github.com/xgcm/xgcm/blob/95f4f33d72d2add00136e27f6b3bedecb97d4d77/.github/workflows/ci.yaml#L50-L57). 

According to https://github.com/codecov/codecov-action#readme, v1 is being phased out, so this was probably our issue.

xref #185