### PR TITLE
Fix typo in storage.py

### DIFF
--- a/pangeo_forge_recipes/storage.py
+++ b/pangeo_forge_recipes/storage.py
@@ -160,7 +160,7 @@ class CacheFSSpecTarget(FlatFSSpecTarget):
 
         input_opener = fsspec.open(fname, mode="rb", **open_kwargs)
         target_opener = self.open(fname, mode="wb")
-        logger.info(f"Coping remote file '{fname}' to cache")
+        logger.info(f"Copying remote file '{fname}' to cache")
         _copy_btw_filesystems(input_opener, target_opener)
 
 


### PR DESCRIPTION
I've been aware of this typo for awhile, but the reason for fixing it now is create a PR to see if #185 fixed #172.

I tried re-running jobs from existing PRs, but they don't appear to run with the new workflow when re-run.

The fact that a typo-fixing PR itself has a typo in its only commit message was not intentional. 