### PR TITLE
Match workflows/main.yaml triggers to xgcm/workflows/ci.yaml

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,6 +25,8 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - name: Setup Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,13 +2,15 @@ name: Tests
 
 on:
   push:
-    branches: "*"
+    branches:
+      - "master"
     paths-ignore:
-    - 'docs/**'
+      - 'docs/**'
   pull_request:
-    branches: master
+    branches:
+      - "*"
     paths-ignore:
-    - 'docs/**'
+      - 'docs/**'
 
 env:
   PYTEST_ADDOPTS: "--color=yes"


### PR DESCRIPTION
As noted in https://github.com/pangeo-forge/pangeo-forge-recipes/issues/172#issuecomment-907408900, [xgcm/.github/workflows/ci.yaml](https://github.com/xgcm/xgcm/blob/master/.github/workflows/ci.yaml) somehow produces Codecov status reports on PRs, whereas our current `main.yaml` fails to do that.

Updating to codecov-action v2 in #185 did not fix the issue.

Based on https://github.com/codecov/codecov-action/issues/95, workflow triggers can affect this. This PR matches our triggers to those of xgcm.