### PR TITLE
Add `netcdf_storage_options` to `HDFReferenceRecipe` tutorial

### DIFF
--- a/docs/tutorials/hdf_reference/reference_cmip6.ipynb
+++ b/docs/tutorials/hdf_reference/reference_cmip6.ipynb
@@ -941,7 +941,7 @@
     "## Define the Recipe\n",
     "\n",
     "Once we have our `FilePattern` defined, defining our Recipe is straightforward.\n",
-    "The only custom option we need is to use `decode_coords='all'` when opening the files."
+    "The only custom options we need are to specify that we'll be accessing the source files anonymously and to use `decode_coords='all'` when opening them."
    ]
   },
   {
@@ -953,7 +953,7 @@
     {
      "data": {
       "text/plain": [
-       "HDFReferenceRecipe(file_pattern=<FilePattern {'time': 15}>, output_json_fname='reference.json', output_intake_yaml_fname='reference.yaml', target=None, metadata_cache=None, netcdf_storage_options={}, inline_threshold=500, output_storage_options={}, template_count=20, xarray_open_kwargs={'decode_coords': 'all'}, xarray_concat_args={})"
+       "HDFReferenceRecipe(file_pattern=<FilePattern {'time': 15}>, output_json_fname='reference.json', output_intake_yaml_fname='reference.yaml', target=None, metadata_cache=None, netcdf_storage_options={'anon': True}, inline_threshold=500, output_storage_options={}, template_count=20, xarray_open_kwargs={'decode_coords': 'all'}, xarray_concat_args={})"
       ]
      },
      "execution_count": 5,
@@ -967,6 +967,7 @@
     "rec = HDFReferenceRecipe(\n",
     "    pattern,\n",
     "    xarray_open_kwargs={\"decode_coords\": \"all\"}\n",
+    "    netcdf_storage_options={\"anon\": True}\n",
     ")\n",
     "rec"
    ]


### PR DESCRIPTION
When I tried to run https://pangeo-forge.readthedocs.io/en/latest/tutorials/hdf_reference/reference_cmip6.html I got a `NoCredentialsError`:

```python
from dask.diagnostics import ProgressBar
delayed = rec.to_dask()
with ProgressBar():
    delayed.compute()
```
<details>

<summary> Traceback </summary>

```
---------------------------------------------------------------------------
NoCredentialsError                        Traceback (most recent call last)
<ipython-input-12-37a4a323521b> in <module>
      1 delayed = rec.to_dask()
      2 with ProgressBar():
----> 3     delayed.compute()

/srv/conda/envs/notebook/lib/python3.8/site-packages/dask/base.py in compute(self, **kwargs)
    277         dask.base.compute
    278         """
--> 279         (result,) = compute(self, traverse=False, **kwargs)
    280         return result
    281 

/srv/conda/envs/notebook/lib/python3.8/site-packages/dask/base.py in compute(*args, **kwargs)
    559         postcomputes.append(x.__dask_postcompute__())
    560 
--> 561     results = schedule(dsk, keys, **kwargs)
    562     return repack([f(r, *a) for r, (f, a) in zip(results, postcomputes)])
    563 

/srv/conda/envs/notebook/lib/python3.8/site-packages/dask/threaded.py in get(dsk, result, cache, num_workers, pool, **kwargs)
     74                 pools[thread][num_workers] = pool
     75 
---> 76     results = get_async(
     77         pool.apply_async,
     78         len(pool._pool),

/srv/conda/envs/notebook/lib/python3.8/site-packages/dask/local.py in get_async(apply_async, num_workers, dsk, result, cache, get_id, rerun_exceptions_locally, pack_exception, raise_exception, callbacks, dumps, loads, **kwargs)
    485                         _execute_task(task, data)  # Re-execute locally
    486                     else:
--> 487                         raise_exception(exc, tb)
    488                 res, worker_id = loads(res_info)
    489                 state["cache"][key] = res

/srv/conda/envs/notebook/lib/python3.8/site-packages/dask/local.py in reraise(exc, tb)
    315     if exc.__traceback__ is not tb:
    316         raise exc.with_traceback(tb)
--> 317     raise exc
    318 
    319 

/srv/conda/envs/notebook/lib/python3.8/site-packages/dask/local.py in execute_task(key, task_info, dumps, loads, get_id, pack_exception)
    220     try:
    221         task, data = loads(task_info)
--> 222         result = _execute_task(task, data)
    223         id = get_id()
    224         result = dumps((result, id))

/srv/conda/envs/notebook/lib/python3.8/site-packages/dask/core.py in _execute_task(arg, cache, dsk)
    119         # temporaries by their reference count and can execute certain
    120         # operations in-place.
--> 121         return func(*(_execute_task(a, cache) for a in args))
    122     elif not ishashable(arg):
    123         return arg

/srv/conda/envs/notebook/lib/python3.8/site-packages/pangeo_forge_recipes/recipes/base.py in _store_chunk(checkpoint, func, input_key)
    211 
    212 def _store_chunk(checkpoint, func, input_key):
--> 213     return func(input_key)
    214 
    215 

/srv/conda/envs/notebook/lib/python3.8/site-packages/pangeo_forge_recipes/recipes/reference_hdf_zarr.py in _one_chunk(chunk_key, file_pattern, netcdf_storage_options, metadata_cache)
    152 ):
    153     fname = file_pattern[chunk_key]
--> 154     with fsspec.open(fname, **netcdf_storage_options) as f:
    155         fn = os.path.basename(fname + ".json")
    156         h5chunks = SingleHdf5ToZarr(f, _unstrip_protocol(fname, f.fs), inline_threshold=300)

/srv/conda/envs/notebook/lib/python3.8/site-packages/fsspec/core.py in __enter__(self)
    100         mode = self.mode.replace("t", "").replace("b", "") + "b"
    101 
--> 102         f = self.fs.open(self.path, mode=mode)
    103 
    104         self.fobjects = [f]

/srv/conda/envs/notebook/lib/python3.8/site-packages/fsspec/spec.py in open(self, path, mode, block_size, cache_options, **kwargs)
    976         else:
    977             ac = kwargs.pop("autocommit", not self._intrans)
--> 978             f = self._open(
    979                 path,
    980                 mode=mode,

/srv/conda/envs/notebook/lib/python3.8/site-packages/s3fs/core.py in _open(self, path, mode, block_size, acl, version_id, fill_cache, cache_type, autocommit, requester_pays, **kwargs)
    536             cache_type = self.default_cache_type
    537 
--> 538         return S3File(
    539             self,
    540             path,

/srv/conda/envs/notebook/lib/python3.8/site-packages/s3fs/core.py in __init__(self, s3, path, mode, block_size, acl, version_id, fill_cache, s3_additional_kwargs, autocommit, cache_type, requester_pays)
   1840                 self.details = s3.info(path)
   1841                 self.version_id = self.details.get("VersionId")
-> 1842         super().__init__(
   1843             s3, path, mode, block_size, autocommit=autocommit, cache_type=cache_type
   1844         )

/srv/conda/envs/notebook/lib/python3.8/site-packages/fsspec/spec.py in __init__(self, fs, path, mode, block_size, autocommit, cache_type, cache_options, **kwargs)
   1304         if mode == "rb":
   1305             if not hasattr(self, "details"):
-> 1306                 self.details = fs.info(path)
   1307             self.size = self.details["size"]
   1308             self.cache = caches[cache_type](

/srv/conda/envs/notebook/lib/python3.8/site-packages/fsspec/asyn.py in wrapper(*args, **kwargs)
     86     def wrapper(*args, **kwargs):
     87         self = obj or args[0]
---> 88         return sync(self.loop, func, *args, **kwargs)
     89 
     90     return wrapper

/srv/conda/envs/notebook/lib/python3.8/site-packages/fsspec/asyn.py in sync(loop, func, timeout, *args, **kwargs)
     67         raise FSTimeoutError
     68     if isinstance(result[0], BaseException):
---> 69         raise result[0]
     70     return result[0]
     71 

/srv/conda/envs/notebook/lib/python3.8/site-packages/fsspec/asyn.py in _runner(event, coro, result, timeout)
     23         coro = asyncio.wait_for(coro, timeout=timeout)
     24     try:
---> 25         result[0] = await coro
     26     except Exception as ex:
     27         result[0] = ex

/srv/conda/envs/notebook/lib/python3.8/site-packages/s3fs/core.py in _info(self, path, bucket, key, refresh, version_id)
   1078                 else:
   1079                     try:
-> 1080                         out = await self._simple_info(path)
   1081                     except PermissionError:
   1082                         # If the permissions aren't enough for scanning a prefix

/srv/conda/envs/notebook/lib/python3.8/site-packages/s3fs/core.py in _simple_info(self, path)
    991         prefix = key.strip("/")
    992 
--> 993         out = await self._call_s3(
    994             "list_objects_v2",
    995             self.kwargs,

/srv/conda/envs/notebook/lib/python3.8/site-packages/s3fs/core.py in _call_s3(self, method, *akwarglist, **kwargs)
    266                 err = e
    267         err = translate_boto_error(err)
--> 268         raise err
    269 
    270     call_s3 = sync_wrapper(_call_s3)

/srv/conda/envs/notebook/lib/python3.8/site-packages/s3fs/core.py in _call_s3(self, method, *akwarglist, **kwargs)
    246         for i in range(self.retries):
    247             try:
--> 248                 out = await method(**additional_kwargs)
    249                 return out
    250             except S3_RETRYABLE_ERRORS as e:

/srv/conda/envs/notebook/lib/python3.8/site-packages/aiobotocore/client.py in _make_api_call(self, operation_name, api_params)
    139             http, parsed_response = event_response
    140         else:
--> 141             http, parsed_response = await self._make_request(
    142                 operation_model, request_dict, request_context)
    143 

/srv/conda/envs/notebook/lib/python3.8/site-packages/aiobotocore/client.py in _make_request(self, operation_model, request_dict, request_context)
    159     async def _make_request(self, operation_model, request_dict, request_context):
    160         try:
--> 161             return await self._endpoint.make_request(operation_model, request_dict)
    162         except Exception as e:
    163             await self.meta.events.emit(

/srv/conda/envs/notebook/lib/python3.8/site-packages/aiobotocore/endpoint.py in _send_request(self, request_dict, operation_model)
     75     async def _send_request(self, request_dict, operation_model):
     76         attempts = 1
---> 77         request = await self.create_request(request_dict, operation_model)
     78         context = request_dict['context']
     79         success_response, exception = await self._get_response(

/srv/conda/envs/notebook/lib/python3.8/site-packages/aiobotocore/endpoint.py in create_request(self, params, operation_model)
     68                 service_id=service_id,
     69                 op_name=operation_model.name)
---> 70             await self._event_emitter.emit(event_name, request=request,
     71                                            operation_name=operation_model.name)
     72         prepared_request = self.prepare_request(request)

/srv/conda/envs/notebook/lib/python3.8/site-packages/aiobotocore/hooks.py in _emit(self, event_name, kwargs, stop_on_response)
     25             # Await the handler if its a coroutine.
     26             if asyncio.iscoroutinefunction(handler):
---> 27                 response = await handler(**kwargs)
     28             else:
     29                 response = handler(**kwargs)

/srv/conda/envs/notebook/lib/python3.8/site-packages/aiobotocore/signers.py in handler(self, operation_name, request, **kwargs)
     14         # this method is invoked to sign the request.
     15         # Don't call this method directly.
---> 16         return await self.sign(operation_name, request)
     17 
     18     async def sign(self, operation_name, request, region_name=None,

/srv/conda/envs/notebook/lib/python3.8/site-packages/aiobotocore/signers.py in sign(self, operation_name, request, region_name, signing_type, expires_in, signing_name)
     61                     raise e
     62 
---> 63             auth.add_auth(request)
     64 
     65     async def get_auth_instance(self, signing_name, region_name,

/srv/conda/envs/notebook/lib/python3.8/site-packages/botocore/auth.py in add_auth(self, request)
    371     def add_auth(self, request):
    372         if self.credentials is None:
--> 373             raise NoCredentialsError()
    374         datetime_now = datetime.datetime.utcnow()
    375         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)

NoCredentialsError: Unable to locate credentials
```

</details>

Adding `netcdf_storage_options={"anon": True}` to the recipe fixed this. This PR adds that kwarg to the tutorial notebook.

