### PR TITLE
Add `from_pickle` option to FilePattern

### DIFF
--- a/pangeo_forge_recipes/patterns.py
+++ b/pangeo_forge_recipes/patterns.py
@@ -135,6 +135,7 @@ class FilePattern:
       the query string of each ``file_pattern`` url at runtime.
     :param is_opendap: If True, assume all input fnames represent opendap endpoints.
       Cannot be used with caching.
+    :param from_pickle: If True, assume all input fnames represent `pickle` files.
     """
 
     def __init__(
@@ -144,12 +145,14 @@ class FilePattern:
         fsspec_open_kwargs: Optional[Dict[str, Any]] = None,
         query_string_secrets: Optional[Dict[str, str]] = None,
         is_opendap: bool = False,
+        from_pickle: bool = False,
     ):
         self.format_function = format_function
         self.combine_dims = combine_dims
         self.fsspec_open_kwargs = fsspec_open_kwargs if fsspec_open_kwargs else {}
         self.query_string_secrets = query_string_secrets if query_string_secrets else {}
         self.is_opendap = is_opendap
+        self.from_pickle = from_pickle
         if self.fsspec_open_kwargs and self.is_opendap:
             raise ValueError(
                 "OPeNDAP inputs are not opened with `fsspec`. "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ import aiohttp
 import fsspec
 import numpy as np
 import pandas as pd
+import pickle
 import pytest
 import xarray as xr
 from dask.distributed import Client, LocalCluster
@@ -270,6 +271,15 @@ def netcdf_local_paths(request):
     return request.param
 
 
+@pytest.fixture(scope="session")
+def netcdf_local_pickle_path(tmpdir_factory, daily_xarray_dataset):
+    tmp_path = tmpdir_factory.mktemp("netcdf_data")
+    fname = tmp_path.join("pickled_dataset.pickle")
+    with open(fname, "wb") as f:
+        pickle.dump(daily_xarray_dataset, f, protocol=-1)
+    return [fname], len(daily_xarray_dataset["time"]), None, None, dict(from_pickle=True)
+
+
 http_auth_params = [
     dict(username="foo", password="bar"),
     dict(required_query_string="foo=foo&bar=bar"),
@@ -321,6 +331,11 @@ def netcdf_local_file_pattern_sequential_multivariable(
 )
 def netcdf_local_file_pattern(request):
     return request.param
+
+
+@pytest.fixture(scope="session")
+def netcdf_local_pickle_file_pattern(netcdf_local_pickle_path):
+    return make_file_pattern(netcdf_local_pickle_path)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ Note:
 """
 import logging
 import os
+import pickle
 import socket
 import subprocess
 import time
@@ -23,7 +24,6 @@ import aiohttp
 import fsspec
 import numpy as np
 import pandas as pd
-import pickle
 import pytest
 import xarray as xr
 from dask.distributed import Client, LocalCluster

--- a/tests/recipe_tests/test_XarrayZarrRecipe.py
+++ b/tests/recipe_tests/test_XarrayZarrRecipe.py
@@ -51,6 +51,23 @@ def netCDFtoZarr_recipe(
 
 
 @pytest.fixture
+def netCDFtoZarr_recipe_from_pickle(
+    netcdf_local_pickle_file_pattern,
+    daily_xarray_dataset,
+    tmp_target,
+    tmp_cache,
+    tmp_metadata_target,
+):
+    return make_netCDFtoZarr_recipe(
+        netcdf_local_pickle_file_pattern,
+        daily_xarray_dataset,
+        tmp_target,
+        tmp_cache,
+        tmp_metadata_target,
+    )
+
+
+@pytest.fixture
 def netCDFtoZarr_http_recipe(
     netcdf_http_file_pattern, daily_xarray_dataset, tmp_target, tmp_cache, tmp_metadata_target
 ):
@@ -99,9 +116,20 @@ def netCDFtoZarr_subset_recipe(
 all_recipes = [
     lazy_fixture("netCDFtoZarr_recipe"),
     lazy_fixture("netCDFtoZarr_subset_recipe"),
+    lazy_fixture("netCDFtoZarr_recipe_from_pickle"),
 ]
 
 recipes_no_subset = [
+    lazy_fixture("netCDFtoZarr_recipe"),
+    lazy_fixture("netCDFtoZarr_recipe_from_pickle"),
+]
+
+recipes_no_pickle = [
+    lazy_fixture("netCDFtoZarr_recipe"),
+    lazy_fixture("netCDFtoZarr_subset_recipe"),
+]
+
+recipes_no_subset_no_pickle = [
     lazy_fixture("netCDFtoZarr_recipe"),
 ]
 
@@ -131,7 +159,7 @@ def test_recipe(recipe_fixture, execute_recipe):
         pass
 
 
-@pytest.mark.parametrize("recipe_fixture", all_recipes)
+@pytest.mark.parametrize("recipe_fixture", recipes_no_pickle)
 @pytest.mark.parametrize("nkeep", [1, 2])
 def test_prune_recipe(recipe_fixture, execute_recipe, nkeep):
     """Check that recipe.copy_pruned works as expected."""
@@ -293,7 +321,7 @@ def do_actual_chunks_test(
         ({"lon": 12}, False, pytest.raises(ValueError)),
     ],
 )
-@pytest.mark.parametrize("recipe_fixture", recipes_no_subset)
+@pytest.mark.parametrize("recipe_fixture", recipes_no_subset_no_pickle)
 def test_chunks(
     recipe_fixture,
     execute_recipe_python,
@@ -319,7 +347,7 @@ def test_chunks(
     "target_chunks,specify_nitems_per_input,error_expectation",
     [({"lon": 12, "time": 3}, False, does_not_raise())],
 )
-@pytest.mark.parametrize("recipe_fixture", recipes_no_subset)
+@pytest.mark.parametrize("recipe_fixture", recipes_no_subset_no_pickle)
 def test_chunks_distributed_locking(
     recipe_fixture,
     execute_recipe_with_dask,

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,3 +1,5 @@
+import pickle
+
 import fsspec
 import xarray as xr
 
@@ -9,6 +11,13 @@ def test_fixture_local_files(daily_xarray_dataset, netcdf_local_paths):
     paths = netcdf_local_paths[0]
     paths = [str(path) for path in paths]
     ds = xr.open_mfdataset(paths, combine="by_coords", concat_dim="time", engine="h5netcdf")
+    assert ds.identical(daily_xarray_dataset)
+
+
+def test_fixture_local_pickle_files(daily_xarray_dataset, netcdf_local_pickle_path):
+    paths = netcdf_local_pickle_path[0]
+    path = paths[0]
+    ds = pickle.load(open(path, "rb"))
     assert ds.identical(daily_xarray_dataset)
 
 


### PR DESCRIPTION
@jbusecke, @dgergel, and I are continuing to explore ways to support real world CMIP6 workflows in Pangeo Forge.

https://github.com/jbusecke/cmip6_derived_cloud_datasets uses Prefect and Coiled to build derived CMIP6 Zarr datasets *without* Pangeo Forge. The first step of that process is [`discovery_and_preprocessing`](https://github.com/jbusecke/cmip6_derived_cloud_datasets/blob/c8ffe41ab692dc1291bc738e22523f8fa4f0aaa8/test.py#L11-L26), which returns a dictionary of preprocessed `xarray.Dataset`s.

> Theoretically, any given dataset in this dictionary should be recreate-able using a combination of `FilePattern` (perhaps with a lot of conditional logic in the `format_function`) and the `process_input`/`process_chunk` kwargs of `XarrayZarrRecipe` (again, likely with a lot of conditionality in the functions passed to those kwargs). The degree of conditional logic development required to make this work may well represent too much friction for real world CMIP6 use cases.

Julius thought of a possible shortcut for plugging his dictionary into Pangeo Forge: if the objects in the CMIP6 dataset dictionary were written out to local pickle files, then they might be able to be arbitrarily executed with his Prefect/Coiled infrastructure or, alternatively, instantiated as an `XarrayZarrRecipe` and executed with Pangeo Forge infrastructure. This turns out to be true (at least for manual execution), as proven by a notebook he screen-shared with me, and requires surprisingly minimal changes to the codebase. This PR (again, h/t Julius for the concept) makes the necessary changes to `pangeo-forge-recipes` so that Julius can continue his experiments by installing `pangeo-forge-recipes` from

```shell
!pip install git+https://github.com/cisaacstern/pangeo-forge-recipes@from-pickle
```

This might be part of an eventual solution for https://github.com/pangeo-forge/pangeo-forge-recipes/issues/176 and the various CMIP6-related issues linked therein. Here is a pseudo-code example of how this feature would be used in combination with Julius's dataset dictionary:

```python
import pickle
from cmip6_derived_cloud_datasets import discovery_and_preprocessing
from pangeo_forge_recipes.patterns import pattern_from_file_sequence
from pangeo_forge_recipes.recipes import XarrayZarrRecipe

dataset_identifiers = { ... }
ds_dict = discovery_and_preprocessing(**dataset_identifiers)

for k, ds in ds_dict:
   with open(f'{k}.pickle', 'wb') as f:
       pickle.dump(ds, f, protocol=-1)

patterns = {
    k: pattern_from_file_sequence(
        [f"{k}.pickle"],
        "time",
        nitems_per_file=len(ds_dict[k]["time"]),
        from_pickle=True,
    ) for k in ds_dict.keys()
}
recipes = {key: XarrayZarrRecipe(pattern) for key, pattern in patterns.items()}
```
Among other things, security is a consideration if we ever choose to support pickled inputs in production. The feature of `pickle` which does not appear to be easily replicated with other intermediate caching methods is its ability&mdash;in theory, at least?&mdash;to encode the entire `xarray.Dataset` (including combinations of arbitrary numbers of remote sources and delayed Dask operations) in a small, portable file that doesn't require `.load()`ing. Currently, the tests I've included with this PR don't test that full suite of potential, but we can certainly expand them to confirm.