### PR TITLE
Consolidate dimension coordinates

### DIFF
--- a/tests/recipe_tests/test_XarrayZarrRecipe.py
+++ b/tests/recipe_tests/test_XarrayZarrRecipe.py
@@ -345,6 +345,19 @@ def test_chunks_distributed_locking(
     )
 
 
+def test_no_consolidate_dimension_coordinates(netCDFtoZarr_recipe):
+    RecipeClass, file_pattern, kwargs, ds_expected, target = netCDFtoZarr_recipe
+
+    rec = RecipeClass(file_pattern, **kwargs)
+    rec.consolidate_dimension_coordinates = False
+    rec.to_function()()
+    ds_actual = xr.open_zarr(target.get_mapper()).load()
+    xr.testing.assert_identical(ds_actual, ds_expected)
+
+    store = zarr.open_consolidated(target.get_mapper())
+    assert store["time"].chunks == (file_pattern.nitems_per_input["time"],)
+
+
 def test_lock_timeout(netCDFtoZarr_recipe_sequential_only, execute_recipe_no_dask):
     RecipeClass, file_pattern, kwargs, ds_expected, target = netCDFtoZarr_recipe_sequential_only
 

--- a/tests/recipe_tests/test_XarrayZarrRecipe.py
+++ b/tests/recipe_tests/test_XarrayZarrRecipe.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 import xarray as xr
+import zarr
 
 # need to import this way (rather than use pytest.lazy_fixture) to make it work with dask
 from pytest_lazyfixture import lazy_fixture
@@ -274,6 +275,10 @@ def do_actual_chunks_test(
         assert all([item == chunk_len for item in ds_actual.chunks[other_dim][:-1]])
 
     ds_actual.load()
+    store = zarr.open_consolidated(target.get_mapper())
+    for dim in ds_actual.dims:
+        assert store[dim].chunks == ds_actual[dim].shape
+
     xr.testing.assert_identical(ds_actual, ds_expected)
 
 


### PR DESCRIPTION
This consolidates dimension coordinates to address the performance
issues from having many small coordinate chunks.

Closes https://github.com/pangeo-forge/pangeo-forge-recipes/issues/209


The tests will fail right now with

```python
/home/taugspurger/src/pangeo-forge/pangeo-forge-recipes/tests/recipe_tests/test_XarrayZarrRecipe.py:282: AssertionError: Left and right Dataset objects are not identical


>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
E   AssertionError: Left and right Dataset objects are not identical

    Differing coordinates:
    L * time     (time) datetime64[ns] NaT 2010-01-02 ... 2010-01-09 2010-01-10
    R * time     (time) datetime64[ns] 2010-01-01 2010-01-02 ... 2010-01-10
    Differing data variables:
    L   foo      (time, lat, lon) float64 0.417 0.7203 0.0001144 ... 0.1179 0.3748
        long_name: Fantastic Foo
    R   foo      (time, lat, lon) float64 0.417 0.7203 0.0001144 ... 0.1179 0.3748
        long_name: Fantastic Foo
    L   bar      (time, lat, lon) int64 9 4 3 2 2 8 0 0 4 8 ... 9 8 4 4 6 0 3 3 9 5
        long_name: Beautiful Bar
    R   bar      (time, lat, lon) int64 9 4 3 2 2 8 0 0 4 8 ... 9 8 4 4 6 0 3 3 9 5
        long_name: Beautiful Bar
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> entering PDB >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
```

it's a bit hard to see, but the `time` value changed. The value of `0` is being interpreted as a NaT by xarray now. I'm sure I'm missing something basic with metadata when rewriting the variable, but I haven't found it yet. Posting this before I figure that out in case someone knows it offhand.