### PR TITLE
Tweak file opening

### DIFF
--- a/pangeo_forge_recipes/recipes/reference_hdf_zarr.py
+++ b/pangeo_forge_recipes/recipes/reference_hdf_zarr.py
@@ -10,7 +10,7 @@ from fsspec_reference_maker.combine import MultiZarrToZarr
 
 from ..patterns import FilePattern, Index
 from ..reference import create_hdf5_reference
-from ..storage import FSSpecTarget, MetadataTarget
+from ..storage import FSSpecTarget, MetadataTarget, file_opener
 from .base import BaseRecipe, FilePatternRecipeMixin
 
 ChunkKey = Index
@@ -151,7 +151,9 @@ def _one_chunk(
 ):
     fname = file_pattern[chunk_key]
     ref_fname = os.path.basename(fname + ".json")
-    metadata_cache[ref_fname] = create_hdf5_reference(fname, **netcdf_storage_options)
+    # with fsspec.open(fname, **netcdf_storage_options) as fp:
+    with file_opener(fname, **netcdf_storage_options) as fp:
+        metadata_cache[ref_fname] = create_hdf5_reference(fp, fname)
 
 
 def _finalize(

--- a/pangeo_forge_recipes/reference.py
+++ b/pangeo_forge_recipes/reference.py
@@ -1,0 +1,26 @@
+"""
+Functions related to creating fsspec references.
+"""
+
+import fsspec
+from fsspec_reference_maker.hdf import SingleHdf5ToZarr
+
+
+def create_hdf5_reference(fname: str, inline_threshold: int = 300, **netcdf_storage_options):
+    with fsspec.open(fname, **netcdf_storage_options) as f:
+        h5chunks = SingleHdf5ToZarr(f, _unstrip_protocol(fname, f.fs), inline_threshold=300)
+        reference_data = h5chunks.translate()
+    return reference_data
+
+
+def _unstrip_protocol(name, fs):
+    # should be upstreamed into fsspec and maybe also
+    # be a method on an OpenFile
+    if isinstance(fs.protocol, str):
+        if name.startswith(fs.protocol):
+            return name
+        return fs.protocol + "://" + name
+    else:
+        if name.startswith(tuple(fs.protocol)):
+            return name
+        return fs.protocol[0] + "://" + name

--- a/pangeo_forge_recipes/reference.py
+++ b/pangeo_forge_recipes/reference.py
@@ -2,14 +2,12 @@
 Functions related to creating fsspec references.
 """
 
-import fsspec
 from fsspec_reference_maker.hdf import SingleHdf5ToZarr
 
 
-def create_hdf5_reference(fname: str, inline_threshold: int = 300, **netcdf_storage_options):
-    with fsspec.open(fname, **netcdf_storage_options) as f:
-        h5chunks = SingleHdf5ToZarr(f, _unstrip_protocol(fname, f.fs), inline_threshold=300)
-        reference_data = h5chunks.translate()
+def create_hdf5_reference(fp, fname: str, inline_threshold: int = 300, **netcdf_storage_options):
+    h5chunks = SingleHdf5ToZarr(fp, _unstrip_protocol(fname, fp.fs), inline_threshold=300)
+    reference_data = h5chunks.translate()
     return reference_data
 
 

--- a/pangeo_forge_recipes/reference.py
+++ b/pangeo_forge_recipes/reference.py
@@ -2,23 +2,27 @@
 Functions related to creating fsspec references.
 """
 
+from typing import Dict, Tuple, Union
+
 from fsspec_reference_maker.hdf import SingleHdf5ToZarr
 
 
-def create_hdf5_reference(fp, fname: str, inline_threshold: int = 300, **netcdf_storage_options):
-    h5chunks = SingleHdf5ToZarr(fp, _unstrip_protocol(fname, fp.fs), inline_threshold=300)
+def create_hdf5_reference(
+    fp, fname: str, url: str, inline_threshold: int = 300, **netcdf_storage_options
+) -> Dict:
+    h5chunks = SingleHdf5ToZarr(fp, url, inline_threshold=inline_threshold)
     reference_data = h5chunks.translate()
     return reference_data
 
 
-def _unstrip_protocol(name, fs):
+def unstrip_protocol(name: str, protocol: Union[str, Tuple[str, ...]]) -> str:
     # should be upstreamed into fsspec and maybe also
     # be a method on an OpenFile
-    if isinstance(fs.protocol, str):
-        if name.startswith(fs.protocol):
+    if isinstance(protocol, str):
+        if name.startswith(protocol):
             return name
-        return fs.protocol + "://" + name
+        return protocol + "://" + name
     else:
-        if name.startswith(tuple(fs.protocol)):
+        if name.startswith(tuple(protocol)):
             return name
-        return fs.protocol[0] + "://" + name
+        return protocol[0] + "://" + name

--- a/pangeo_forge_recipes/storage.py
+++ b/pangeo_forge_recipes/storage.py
@@ -201,6 +201,7 @@ def file_opener(
         before opening. In this case, function yields a path name rather than an open file.
     :param bypass_open: If True, skip trying to open the file at all and just
         return the filename back directly. (A fancy way of doing nothing!)
+    :param secrets: Dictionary of secrets to encode into the query string.
     """
 
     if bypass_open:

--- a/pangeo_forge_recipes/storage.py
+++ b/pangeo_forge_recipes/storage.py
@@ -9,7 +9,7 @@ import unicodedata
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Iterator, Optional, Sequence, Union
+from typing import Iterator, Optional, Sequence, Union
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import fsspec
@@ -18,7 +18,6 @@ from fsspec.implementations.http import BlockSizeError
 logger = logging.getLogger(__name__)
 
 # fsspec doesn't provide type hints, so I'm not sure what the write type is for open files
-OpenFileType = Any
 
 
 def _get_url_size(fname, secrets, **open_kwargs):
@@ -116,7 +115,7 @@ class FSSpecTarget(AbstractTarget):
         return self.fs.size(self._full_path(path))
 
     @contextmanager
-    def open(self, path: str, **kwargs) -> Iterator[None]:
+    def open(self, path: str, **kwargs) -> Iterator[fsspec.core.OpenFile]:
         """Open file with a context manager."""
         full_path = self._full_path(path)
         logger.debug(f"entering fs.open context manager for {full_path}")
@@ -194,7 +193,7 @@ def file_opener(
     bypass_open: bool = False,
     secrets: Optional[dict] = None,
     **open_kwargs,
-) -> Iterator[Union[OpenFileType, str]]:
+) -> Iterator[Union[fsspec.core.OpenFile, str]]:
     """
     Context manager for opening files.
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -98,6 +98,7 @@ def test_file_opener(
                         ds.load()
                     else:
                         _ = fp.read()
+                    assert hasattr(fp, "fs")  # should be true for fsspec.OpenFile objects
 
     if use_dask:
         with Client(dask_cluster) as client:


### PR DESCRIPTION
This PR is in preparation for making XarrayZarrRecipe use fsspec-references for opening NetCDF files.

I have moved some of the reference stuff into its own module `reference.py` and call this from `reference_hdf_zarr.py`.

I have also changed `reference_hdf_zarr` to use the `storage.file_opener` function. This revealed some inconsistencies with return types of that function. Specifically, `file_opener` was previously yielding and `_io.BufferedReader` object in some cases and an `fsspec.OpenFile` object in others (specifically, when opening from cache). Now it will _always_ yield `fsspec.OpenFile`s.

