### PR TITLE
Pass kwargs through to pruned FilePatterns

### DIFF
--- a/pangeo_forge_recipes/patterns.py
+++ b/pangeo_forge_recipes/patterns.py
@@ -268,9 +268,10 @@ def prune_pattern(fp: FilePattern, nkeep: int = 2) -> FilePattern:
         else:  # pragma: no cover
             assert "Should never happen"
 
-    sig = inspect.signature(fp.__init__)
+    sig = inspect.signature(fp.__init__)  # type: ignore
     kwargs = {
-        param: getattr(fp, param) for param in sig.parameters.keys()
-        if param not in ['format_function', 'combine_dims']
+        param: getattr(fp, param)
+        for param in sig.parameters.keys()
+        if param not in ["format_function", "combine_dims"]
     }
     return FilePattern(fp.format_function, *new_combine_dims, **kwargs)

--- a/pangeo_forge_recipes/patterns.py
+++ b/pangeo_forge_recipes/patterns.py
@@ -267,4 +267,10 @@ def prune_pattern(fp: FilePattern, nkeep: int = 2) -> FilePattern:
         else:  # pragma: no cover
             assert "Should never happen"
 
-    return FilePattern(fp.format_function, *new_combine_dims)
+    return FilePattern(
+        fp.format_function,
+        *new_combine_dims,
+        fsspec_open_kwargs=fp.fsspec_open_kwargs,
+        query_string_secrets=fp.query_string_secrets,
+        is_opendap=fp.is_opendap,
+    )

--- a/pangeo_forge_recipes/patterns.py
+++ b/pangeo_forge_recipes/patterns.py
@@ -2,6 +2,7 @@
 Filename / URL patterns.
 """
 
+import inspect
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from itertools import product
@@ -267,10 +268,9 @@ def prune_pattern(fp: FilePattern, nkeep: int = 2) -> FilePattern:
         else:  # pragma: no cover
             assert "Should never happen"
 
-    return FilePattern(
-        fp.format_function,
-        *new_combine_dims,
-        fsspec_open_kwargs=fp.fsspec_open_kwargs,
-        query_string_secrets=fp.query_string_secrets,
-        is_opendap=fp.is_opendap,
-    )
+    sig = inspect.signature(fp.__init__)
+    kwargs = {
+        param: getattr(fp, param) for param in sig.parameters.keys()
+        if param not in ['format_function', 'combine_dims']
+    }
+    return FilePattern(fp.format_function, *new_combine_dims, **kwargs)

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -29,13 +29,8 @@ def make_concat_merge_pattern(**kwargs):
     def format_function(time, variable):
         return f"T_{time}_V_{variable}"
 
-    if "fsspec_open_kwargs" in kwargs.keys() and "is_opendap" in kwargs.keys():
-        with pytest.raises(ValueError):
-            fp = FilePattern(format_function, merge, concat, **kwargs)
-            return
-    else:
-        fp = FilePattern(format_function, merge, concat, **kwargs)
-        return fp, times, varnames, format_function, kwargs
+    fp = FilePattern(format_function, merge, concat, **kwargs)
+    return fp, times, varnames, format_function, kwargs
 
 
 @pytest.fixture
@@ -47,7 +42,6 @@ def concat_merge_pattern():
     params=[
         dict(fsspec_open_kwargs={"block_size": "foo"}),
         dict(is_opendap=True),
-        dict(fsspec_open_kwargs={"block_size": "foo"}, is_opendap=True),
     ]
 )
 def concat_merge_pattern_with_kwargs(request):
@@ -146,6 +140,13 @@ def test_file_pattern_concat_merge(runtime_secrets, pickle, concat_merge_pattern
         assert fp.is_opendap == kwargs["is_opendap"]
         assert fp.is_opendap is True
         assert fp.fsspec_open_kwargs == {}
+
+
+def test_incompatible_kwargs():
+    kwargs = dict(fsspec_open_kwargs={"block_size": "foo"}, is_opendap=True)
+    with pytest.raises(ValueError):
+        make_concat_merge_pattern(**kwargs)
+        return
 
 
 @pytest.mark.parametrize("nkeep", [1, 2])

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,3 +1,5 @@
+import inspect
+
 import pytest
 
 from pangeo_forge_recipes.patterns import (
@@ -172,5 +174,13 @@ def test_prune(nkeep, concat_merge_pattern_with_kwargs, runtime_secrets):
     fp_pruned = prune_pattern(fp, nkeep=nkeep)
     assert fp_pruned.dims == {"variable": 2, "time": nkeep}
     assert len(list(fp_pruned.items())) == 2 * nkeep
-    assert fp.fsspec_open_kwargs == fp_pruned.fsspec_open_kwargs
-    assert fp.is_opendap == fp_pruned.is_opendap
+
+    def get_kwargs(file_pattern):
+        sig = inspect.signature(file_pattern.__init__)
+        kwargs = {
+            param: getattr(file_pattern, param) for param in sig.parameters.keys()
+            if param not in ['combine_dims']
+        }
+        return kwargs
+
+    assert get_kwargs(fp) == get_kwargs(fp_pruned)

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -54,6 +54,17 @@ def concat_merge_pattern_with_kwargs(request):
     return make_concat_merge_pattern(**request.param)
 
 
+@pytest.fixture(
+    params=[
+        {},
+        dict(fsspec_open_kwargs={"username": "foo", "password": "bar"}),
+        dict(query_string_secrets={"token": "foo"}),
+    ]
+)
+def runtime_secrets(request):
+    return request.param
+
+
 def test_file_pattern_concat(concat_pattern):
     fp = concat_pattern
     assert fp.dims == {"time": 3}
@@ -80,14 +91,6 @@ def test_pattern_from_file_sequence():
         assert fp[key] == file_sequence[key[0].index]
 
 
-@pytest.mark.parametrize(
-    "runtime_secrets",
-    [
-        {},
-        dict(fsspec_open_kwargs={"username": "foo", "password": "bar"}),
-        dict(query_string_secrets={"token": "foo"}),
-    ],
-)
 @pytest.mark.parametrize("pickle", [False, True])
 def test_file_pattern_concat_merge(runtime_secrets, pickle, concat_merge_pattern_with_kwargs):
     if not concat_merge_pattern_with_kwargs:
@@ -145,14 +148,6 @@ def test_file_pattern_concat_merge(runtime_secrets, pickle, concat_merge_pattern
         assert fp.fsspec_open_kwargs == {}
 
 
-@pytest.mark.parametrize(
-    "runtime_secrets",
-    [
-        {},
-        dict(fsspec_open_kwargs={"username": "foo", "password": "bar"}),
-        dict(query_string_secrets={"token": "foo"}),
-    ],
-)
 @pytest.mark.parametrize("nkeep", [1, 2])
 def test_prune(nkeep, concat_merge_pattern_with_kwargs, runtime_secrets):
     if not concat_merge_pattern_with_kwargs:

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -87,19 +87,20 @@ def test_pattern_from_file_sequence():
 
 @pytest.mark.parametrize("pickle", [False, True])
 def test_file_pattern_concat_merge(runtime_secrets, pickle, concat_merge_pattern_with_kwargs):
-    if not concat_merge_pattern_with_kwargs:
-        # if `fsspec_open_kwargs` are passed with `is_opendap`, `FilePattern.__init__` raises
-        # ValueError and `concat_merge_pattern_with_kwargs` returns None, so nothing to test
-        return
-    else:
-        fp, times, varnames, format_function, kwargs = concat_merge_pattern_with_kwargs
+
+    fp, times, varnames, format_function, kwargs = concat_merge_pattern_with_kwargs
 
     if runtime_secrets:
         if "fsspec_open_kwargs" in runtime_secrets.keys():
             if not fp.is_opendap:
                 fp.fsspec_open_kwargs.update(runtime_secrets["fsspec_open_kwargs"])
             else:
-                return
+                pytest.skip(
+                    "`fsspec_open_kwargs` should never be used in combination with `is_opendap`. "
+                    "This is checked in `FilePattern.__init__` but not when updating attributes. "
+                    "Proposed changes to secret handling will obviate the need for runtime updates"
+                    " to attributes in favor of encryption. So for now, we'll just skip this."
+                )
         if "query_string_secrets" in runtime_secrets.keys():
             fp.query_string_secrets.update(runtime_secrets["query_string_secrets"])
 
@@ -151,10 +152,6 @@ def test_incompatible_kwargs():
 
 @pytest.mark.parametrize("nkeep", [1, 2])
 def test_prune(nkeep, concat_merge_pattern_with_kwargs, runtime_secrets):
-    if not concat_merge_pattern_with_kwargs:
-        # if `fsspec_open_kwargs` are passed with `is_opendap`, `FilePattern.__init__` raises
-        # ValueError and `concat_merge_pattern_with_kwargs` returns None, so nothing to test
-        return
 
     fp = concat_merge_pattern_with_kwargs[0]
 
@@ -163,7 +160,12 @@ def test_prune(nkeep, concat_merge_pattern_with_kwargs, runtime_secrets):
             if not fp.is_opendap:
                 fp.fsspec_open_kwargs.update(runtime_secrets["fsspec_open_kwargs"])
             else:
-                return
+                pytest.skip(
+                    "`fsspec_open_kwargs` should never be used in combination with `is_opendap`. "
+                    "This is checked in `FilePattern.__init__` but not when updating attributes. "
+                    "Proposed changes to secret handling will obviate the need for runtime updates"
+                    " to attributes in favor of encryption. So for now, we'll just skip this."
+                )
         if "query_string_secrets" in runtime_secrets.keys():
             fp.query_string_secrets.update(runtime_secrets["query_string_secrets"])
 

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -146,8 +146,14 @@ def test_file_pattern_concat_merge(runtime_secrets, pickle, concat_merge_pattern
 
 
 @pytest.mark.parametrize("nkeep", [1, 2])
-def test_prune(nkeep, concat_merge_pattern):
-    fp = concat_merge_pattern[0]
+def test_prune(nkeep, concat_merge_pattern_with_kwargs):
+    if not concat_merge_pattern_with_kwargs:
+        # if `fsspec_open_kwargs` are passed with `is_opendap`, `FilePattern.__init__` raises
+        # ValueError and `concat_merge_pattern_with_kwargs` returns None, so nothing to test
+        return
+    fp = concat_merge_pattern_with_kwargs[0]
     fp_pruned = prune_pattern(fp, nkeep=nkeep)
     assert fp_pruned.dims == {"variable": 2, "time": nkeep}
     assert len(list(fp_pruned.items())) == 2 * nkeep
+    assert fp.fsspec_open_kwargs == fp_pruned.fsspec_open_kwargs
+    assert fp.is_opendap == fp_pruned.is_opendap

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -40,12 +40,7 @@ def concat_merge_pattern():
     return make_concat_merge_pattern()
 
 
-@pytest.fixture(
-    params=[
-        dict(fsspec_open_kwargs={"block_size": "foo"}),
-        dict(is_opendap=True),
-    ]
-)
+@pytest.fixture(params=[dict(fsspec_open_kwargs={"block_size": "foo"}), dict(is_opendap=True)])
 def concat_merge_pattern_with_kwargs(request):
     return make_concat_merge_pattern(**request.param)
 
@@ -178,8 +173,9 @@ def test_prune(nkeep, concat_merge_pattern_with_kwargs, runtime_secrets):
     def get_kwargs(file_pattern):
         sig = inspect.signature(file_pattern.__init__)
         kwargs = {
-            param: getattr(file_pattern, param) for param in sig.parameters.keys()
-            if param not in ['combine_dims']
+            param: getattr(file_pattern, param)
+            for param in sig.parameters.keys()
+            if param not in ["combine_dims"]
         }
         return kwargs
 


### PR DESCRIPTION
@sharkinsspatial, I believe this closes https://github.com/pangeo-forge/pangeo-forge-recipes/issues/207.

Maybe it's worth running a `/run-recipe-test` for the recipe described in that Issue to be sure? I'm pretty confident the tests added here now cover that bug, but running this against the real world Issue would certainly be a good gut check, if it's not too hard for you to do.