### PR TITLE
Let XarrayZarrRecipe use fsspec references for opening netCDF inputs

### DIFF
--- a/tests/recipe_tests/test_XarrayZarrRecipe.py
+++ b/tests/recipe_tests/test_XarrayZarrRecipe.py
@@ -133,6 +133,17 @@ def test_recipe(recipe_fixture, execute_recipe):
 
 
 @pytest.mark.parametrize("recipe_fixture", all_recipes)
+def test_recipe_with_references(recipe_fixture, execute_recipe):
+    """Same as above, but use fsspec references for opening the files."""
+
+    RecipeClass, file_pattern, kwargs, ds_expected, target = recipe_fixture
+    rec = RecipeClass(file_pattern, open_input_with_fsspec_reference=True, **kwargs)
+    execute_recipe(rec)
+    ds_actual = xr.open_zarr(target.get_mapper()).load()
+    xr.testing.assert_identical(ds_actual, ds_expected)
+
+
+@pytest.mark.parametrize("recipe_fixture", all_recipes)
 @pytest.mark.parametrize("nkeep", [1, 2])
 def test_prune_recipe(recipe_fixture, execute_recipe, nkeep):
     """Check that recipe.copy_pruned works as expected."""


### PR DESCRIPTION
Potentially closes #177 by allowing us to bypass h5py when reading netCDF inputs from cloud storage.

After #213 this is pretty simple.

The tests should fail like this

```
recipe-netcdf_local_file_pattern_sequential-netcdf_local_paths_sequential_2d-execute_recipe_manual] FAILED [  6%]

=================================================== FAILURES ===================================================
_ test_recipe_with_references[execute_recipe_no_prefect-netCDFtoZarr_recipe-netcdf_local_file_pattern_sequential-netcdf_local_paths_sequential_2d-execute_recipe_manual] _

recipe_fixture = (<class 'pangeo_forge_recipes.recipes.xarray_zarr.XarrayZarrRecipe'>, <FilePattern {'time': 5}>, {'input_cache': Cache...t 0x1801146a0>, root_path='/private/var/folders/n8/63q49ms55wxcj_gfbtykwp5r0000gn/T/pytest-of-rpa/pytest-45/target11'))
execute_recipe = <function execute_recipe_manual.<locals>.execute at 0x180e78ee0>

    @pytest.mark.parametrize("recipe_fixture", all_recipes)
    def test_recipe_with_references(recipe_fixture, execute_recipe):
        """Same as above, but use fsspec references for opening the files."""
    
        RecipeClass, file_pattern, kwargs, ds_expected, target = recipe_fixture
        rec = RecipeClass(file_pattern, open_input_with_fsspec_reference=True, **kwargs)
        execute_recipe(rec)
        ds_actual = xr.open_zarr(target.get_mapper()).load()
>       xr.testing.assert_identical(ds_actual, ds_expected)
E       AssertionError: Left and right Dataset objects are not identical
E       
E       Differing coordinates:
E       L * time     (time) datetime64[ns] 2010-01-01 2010-01-02 ... 2010-01-10
E           NAME: time
E           _Netcdf4Dimid: 0
E       R * time     (time) datetime64[ns] 2010-01-01 2010-01-02 ... 2010-01-10
E       L * lon      (lon) float64 5.0 15.0 25.0 35.0 45.0 ... 325.0 335.0 345.0 355.0
E           NAME: lon
E           _Netcdf4Dimid: 2
E           long_name: longitude
E           units: degrees_east
E       R * lon      (lon) float64 5.0 15.0 25.0 35.0 45.0 ... 325.0 335.0 345.0 355.0
E           units: degrees_east
E           long_name: longitude
E       L * lat      (lat) float64 5.0 15.0 25.0 35.0 45.0 ... 145.0 155.0 165.0 175.0
E           NAME: lat
E           _Netcdf4Dimid: 1
E           long_name: latitude
E           units: degrees_north
E       R * lat      (lat) float64 5.0 15.0 25.0 35.0 45.0 ... 145.0 155.0 165.0 175.0
E           units: degrees_north
E           long_name: latitude
E       Differing data variables:
E       L   foo      (time, lat, lon) float64 0.417 0.7203 0.0001144 ... 0.1179 0.3748
E           _Netcdf4Coordinates: [0, 1, 2]
E           _Netcdf4Dimid: 0
E           long_name: Fantastic Foo
E       R   foo      (time, lat, lon) float64 0.417 0.7203 0.0001144 ... 0.1179 0.3748
E           long_name: Fantastic Foo
E       L   bar      (time, lat, lon) float64 9.0 4.0 3.0 2.0 2.0 ... 3.0 3.0 9.0 5.0
E           _Netcdf4Coordinates: [0, 1, 2]
E           _Netcdf4Dimid: 0
E           long_name: Beautiful Bar
E       R   bar      (time, lat, lon) int64 9 4 3 2 2 8 0 0 4 8 ... 9 8 4 4 6 0 3 3 9 5
E           long_name: Beautiful Bar
E       Attributes only on the left object:
E           _NCProperties: version=2,netcdf=4.8.0,hdf5=1.10.6

tests/recipe_tests/test_XarrayZarrRecipe.py:143: AssertionError
```

It looks like fsspec-reference-maker is giving more metadata attributes than the h5netcdf library.

