### PR TITLE
Apache Beam Executor

### DIFF
--- a/ci/py3.8.yml
+++ b/ci/py3.8.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3.8
   - aiohttp
+  - apache_beam
   - black
   - boto3
   - cfgrib<0.9.9.0

--- a/ci/py3.9.yml
+++ b/ci/py3.9.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3.9
   - aiohttp
+  - apache_beam
   - black
   - boto3
   - cfgrib<0.9.9.0

--- a/ci/py3.9.yml
+++ b/ci/py3.9.yml
@@ -4,7 +4,6 @@ channels:
 dependencies:
   - python=3.9
   - aiohttp
-  - apache-beam
   - black
   - boto3
   - cfgrib<0.9.9.0

--- a/docs/development/release_notes.md
+++ b/docs/development/release_notes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## v0.7.0 - unreleased
+
+- Apache Beam executor added. {issue}`169`. By [Alex Merose](https://github.com/alxmrs).
+
 ## v0.6.1 - 2021-10-25
 
 - Major internal refactor of executors. {pull}`219`.

--- a/docs/development/release_notes.md
+++ b/docs/development/release_notes.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## v0.6.1 - Unreleased
+## v0.6.1 - 2021-10-25
 
 - Major internal refactor of executors. {pull}`219`.
   Began deprecation cycle for recipe methods (e.g. `recipe.prepare_target()`) in

--- a/docs/recipe_user_guide/execution.md
+++ b/docs/recipe_user_guide/execution.md
@@ -104,3 +104,19 @@ flow.run()
 ```
 
 By default the flow is run using Prefect's [LocalExecutor](https://docs.prefect.io/orchestration/flow_config/executors.html#localexecutor). See [executors](https://docs.prefect.io/orchestration/flow_config/executors.html) for more.
+
+### Beam PTransform
+
+You can convert your recipe to an Apache Beam [PTransform](https://beam.apache.org/documentation/programming-guide/#transforms)
+to be used within a [Pipeline](https://beam.apache.org/documentation/programming-guide/#creating-a-pipeline) using the
+:meth:`BaseRecipe.to_beam()` method. For example
+
+```{code-block} python
+import apache_beam as beam
+
+with beam.Pipeline() as p:
+   p | recipe.to_beam()
+```
+
+By default the pipeline runs using Beam's [DirectRunner](https://beam.apache.org/documentation/runners/direct/).
+See [runners](https://beam.apache.org/documentation/#runners) for more.

--- a/pangeo_forge_recipes/executors/beam.py
+++ b/pangeo_forge_recipes/executors/beam.py
@@ -52,6 +52,7 @@ class _SingleArgumentStage(beam.PTransform):
         return (
             pcoll
             | "Prepare" >> beam.FlatMap(self.prepare_stage)
+            | beam.Reshuffle()
             | "Execute" >> beam.MapTuple(self.exec_stage)
             | beam.combiners.ToList()
             | "Validate" >> beam.Map(self.post_validate)

--- a/pangeo_forge_recipes/executors/beam.py
+++ b/pangeo_forge_recipes/executors/beam.py
@@ -7,11 +7,11 @@ import apache_beam as beam
 from .base import Config, NoArgumentStageFunction, Pipeline, PipelineExecutor, Stage
 
 
-def _no_arg_stage(last: int, *, current: int, func: NoArgumentStageFunction, config: Config) -> int:
+def _no_arg_stage(last: int, *, current: int, fun: NoArgumentStageFunction, config: Config) -> int:
     """Execute a NoArgumentStageFunction, ensuring execution order."""
     assert (last + 1) == current, f"stages are executing out of order! On step {current!r}."
 
-    func(config=config)
+    fun(config=config)
 
     return current
 
@@ -67,7 +67,7 @@ class BeamPipelineExecutor(PipelineExecutor[beam.PTransform]):
                 pcoll |= stage.name >> _SingleArgumentStage(step, stage, pipeline.config)
             else:
                 pcoll |= stage.name >> beam.Map(
-                    _no_arg_stage, current=step, func=stage.function, config=pipeline.config
+                    _no_arg_stage, current=step, fun=stage.function, config=pipeline.config
                 )
 
         return pcoll

--- a/pangeo_forge_recipes/executors/beam.py
+++ b/pangeo_forge_recipes/executors/beam.py
@@ -1,26 +1,75 @@
-from typing import Optional, Iterable
+import itertools
+from dataclasses import dataclass
+from typing import Optional, Iterable, Tuple, Any, List
 
 import apache_beam as beam
 
-from .base import Pipeline, PipelineExecutor, Config, StageFunction
+from .base import (
+    Pipeline,
+    PipelineExecutor,
+    Config,
+    Stage,
+    NoArgumentStageFunction,
+    SingleArgumentStageFunction
+)
 
 
-def exec_ordered(last: int,
-                 *,
-                 current: int,
-                 function: StageFunction,
-                 config: Config,
-                 mappable: Optional[Iterable]) -> int:
-    """Execute a Pipeline Stage, ensuring execution order."""
-    assert (last + 1) == current, 'stages are executing out of order!'
+def _exec_no_arg_stage(
+    last: int, *, current: int, function: NoArgumentStageFunction, config: Config
+) -> int:
+    """Execute a NoArgumentStageFunction, ensuring execution order."""
+    assert (last + 1) == current, f'stages are executing out of order! On step {current!r}.'
 
-    if mappable is not None:
-        for m in mappable:
-            function(m, config=config)
-    else:
-        function(config=config)
+    function(config=config)
 
     return current
+
+
+def _no_op(arg, config=None) -> None:
+    pass
+
+
+@dataclass()
+class _SingleArgumentStage(beam.PTransform):
+    """Execute mappable stage in parallel."""
+
+    step: int
+    stage: Stage
+    config: Config
+
+    @staticmethod
+    def prepare_stage(last: int, *, current: int, mappable: Iterable) -> Iterable[Tuple[int, Any]]:
+        """Propagate current stage to Mappables for parallel execution."""
+        assert (last + 1) == current, f'stages are executing out of order! On step {current!r}.'
+        return zip(itertools.repeat(current), mappable)
+
+    @staticmethod
+    def exec_stage(
+        last: int, arg,
+        current: int = -1, function: SingleArgumentStageFunction = _no_op, config: Optional[Config] = None
+    ) -> int:
+        """Execute stage function."""
+        assert last == current, f'stages are executing out of order! On step {current!r}.'
+
+        function(arg, config=config)
+
+        return current
+
+    @staticmethod
+    def post_validate(last: List[int], *, current: int) -> int:
+        """Propagate step number for downstream stage validation."""
+        assert all([it == current for it in last]), f'stages are executing out of order! On step {current!r}.'
+        return current
+
+    def expand(self, pcoll):
+        return (
+                pcoll
+                | "Prepare" >> beam.FlatMap(self.prepare_stage, current=self.step, mappable=self.stage.mappable)
+                | "Execute" >> beam.MapTuple(self.exec_stage, current=self.step, function=self.stage.function,
+                                             config=self.config)
+                | beam.combiners.ToList()
+                | "Validate" >> beam.Map(self.post_validate, current=self.step)
+        )
 
 
 class BeamPipelineExecutor(PipelineExecutor[beam.PTransform]):
@@ -28,15 +77,18 @@ class BeamPipelineExecutor(PipelineExecutor[beam.PTransform]):
     def compile(pipeline: Pipeline) -> beam.PTransform:
         pcoll = beam.Create([-1])
         for step, stage in enumerate(pipeline.stages):
-            pcoll |= stage.name >> beam.Map(exec_ordered,
-                                            current=step,
-                                            function=stage.function,
-                                            mappable=stage.mappable,
-                                            config=pipeline.config)
+            if stage.mappable is not None:
+                pcoll |= stage.name >> _SingleArgumentStage(step, stage, pipeline.config)
+            else:
+                pcoll |= stage.name >> beam.Map(_exec_no_arg_stage,
+                                                current=step,
+                                                function=stage.function,
+                                                config=pipeline.config)
 
         return pcoll
 
     @staticmethod
     def execute(plan: beam.PTransform, *args, **kwargs):
+        """Execute a plan. All args and kwargs are pass to a `apache_beam.Pipeline`."""
         with beam.Pipeline(*args, **kwargs) as p:
             p | plan

--- a/pangeo_forge_recipes/executors/beam.py
+++ b/pangeo_forge_recipes/executors/beam.py
@@ -1,0 +1,42 @@
+from typing import Optional, Iterable
+
+import apache_beam as beam
+
+from .base import Pipeline, PipelineExecutor, Config, StageFunction
+
+
+def exec_ordered(last: int,
+                 *,
+                 current: int,
+                 function: StageFunction,
+                 config: Config,
+                 mappable: Optional[Iterable]) -> int:
+    """Execute a Pipeline Stage, ensuring execution order."""
+    assert (last + 1) == current, 'stages are executing out of order!'
+
+    if mappable is not None:
+        for m in mappable:
+            function(m, config=config)
+    else:
+        function(config=config)
+
+    return current
+
+
+class BeamPipelineExecutor(PipelineExecutor[beam.PTransform]):
+    @staticmethod
+    def compile(pipeline: Pipeline) -> beam.PTransform:
+        pcoll = beam.Create([-1])
+        for step, stage in enumerate(pipeline.stages):
+            pcoll |= stage.name >> beam.Map(exec_ordered,
+                                            current=step,
+                                            function=stage.function,
+                                            mappable=stage.mappable,
+                                            config=pipeline.config)
+
+        return pcoll
+
+    @staticmethod
+    def execute(plan: beam.PTransform, *args, **kwargs):
+        with beam.Pipeline(*args, **kwargs) as p:
+            p | plan

--- a/pangeo_forge_recipes/recipes/base.py
+++ b/pangeo_forge_recipes/recipes/base.py
@@ -27,6 +27,11 @@ class BaseRecipe(ABC):
 
         return PrefectPipelineExecutor.compile(self._compiler())
 
+    def to_beam(self):
+        from pangeo_forge_recipes.executors.beam import BeamPipelineExecutor
+
+        return BeamPipelineExecutor.compile(self._compiler())
+
 
 RecipeCompiler = Callable[[BaseRecipe], Pipeline]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ max-line-length = 100
 
 [isort]
 known_first_party=pangeo_forge_recipes
-known_third_party=aiohttp,click,dask,fsspec,fsspec_reference_maker,mypy_extensions,numpy,pandas,prefect,pytest,pytest_lazyfixture,setuptools,xarray,yaml,zarr
+known_third_party=aiohttp,apache_beam,click,dask,fsspec,fsspec_reference_maker,mypy_extensions,numpy,pandas,prefect,pytest,pytest_lazyfixture,setuptools,xarray,yaml,zarr
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -5,11 +5,20 @@ Test Pipline Executors
 import pytest
 from pytest_lazyfixture import lazy_fixture
 
-from pangeo_forge_recipes.executors.base import Pipeline, Stage
-from pangeo_forge_recipes.executors.beam import BeamPipelineExecutor
+from pangeo_forge_recipes.executors.base import Pipeline, PipelineExecutor, Stage
 from pangeo_forge_recipes.executors.dask import DaskPipelineExecutor
 from pangeo_forge_recipes.executors.function import FunctionPipelineExecutor
 from pangeo_forge_recipes.executors.prefect import PrefectPipelineExecutor
+
+# Only run Beam executor tests if Beam is in the current test environment.
+try:
+    from pangeo_forge_recipes.executors.beam import BeamPipelineExecutor
+except (ImportError, AttributeError):
+
+    class BeamPipelineExecutor(PipelineExecutor[None]):
+        @staticmethod
+        def compile(pipeline: Pipeline) -> None:
+            pytest.skip()
 
 
 @pytest.fixture

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,6 +1,7 @@
 """
 Test Pipline Executors
 """
+import importlib
 
 import pytest
 from pytest_lazyfixture import lazy_fixture
@@ -58,7 +59,7 @@ def pipeline_with_config(tmpdir_factory):
 )
 def Executor(request):
     try:
-        module = pytest.importorskip(request.param[0])
+        module = importlib.import_module(request.param[0])
         return getattr(module, request.param[1])
     except (AttributeError, ImportError):
         pytest.skip()

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -9,6 +9,7 @@ from pangeo_forge_recipes.executors.base import Pipeline, Stage
 from pangeo_forge_recipes.executors.dask import DaskPipelineExecutor
 from pangeo_forge_recipes.executors.function import FunctionPipelineExecutor
 from pangeo_forge_recipes.executors.prefect import PrefectPipelineExecutor
+from pangeo_forge_recipes.executors.beam import BeamPipelineExecutor
 
 
 @pytest.fixture
@@ -51,7 +52,7 @@ def pipeline_with_config(tmpdir_factory):
 
 
 @pytest.mark.parametrize(
-    "Executor", [FunctionPipelineExecutor, PrefectPipelineExecutor, DaskPipelineExecutor],
+    "Executor", [FunctionPipelineExecutor, PrefectPipelineExecutor, DaskPipelineExecutor, BeamPipelineExecutor],
 )
 @pytest.mark.parametrize(
     "pipeline_config_tmpdir",
@@ -69,4 +70,4 @@ def test_pipeline(pipeline_config_tmpdir, Executor):
         f"{prefix}func1_b.log",
         f"{prefix}func1_3.log",
     ]:
-        assert tmpdir.join(fname).check(file=True)
+        assert tmpdir.join(fname).check(file=True), f'File not found in temporary directory: {fname}.'

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -6,10 +6,10 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 
 from pangeo_forge_recipes.executors.base import Pipeline, Stage
+from pangeo_forge_recipes.executors.beam import BeamPipelineExecutor
 from pangeo_forge_recipes.executors.dask import DaskPipelineExecutor
 from pangeo_forge_recipes.executors.function import FunctionPipelineExecutor
 from pangeo_forge_recipes.executors.prefect import PrefectPipelineExecutor
-from pangeo_forge_recipes.executors.beam import BeamPipelineExecutor
 
 
 @pytest.fixture
@@ -52,7 +52,8 @@ def pipeline_with_config(tmpdir_factory):
 
 
 @pytest.mark.parametrize(
-    "Executor", [FunctionPipelineExecutor, PrefectPipelineExecutor, DaskPipelineExecutor, BeamPipelineExecutor],
+    "Executor",
+    [FunctionPipelineExecutor, PrefectPipelineExecutor, DaskPipelineExecutor, BeamPipelineExecutor],
 )
 @pytest.mark.parametrize(
     "pipeline_config_tmpdir",
@@ -70,4 +71,4 @@ def test_pipeline(pipeline_config_tmpdir, Executor):
         f"{prefix}func1_b.log",
         f"{prefix}func1_3.log",
     ]:
-        assert tmpdir.join(fname).check(file=True), f'File not found in temporary directory: {fname}.'
+        assert tmpdir.join(fname).check(file=True), f"File not found in temp directory: {fname}."


### PR DESCRIPTION
The pangeo-forge pipeline model is adapted to run on Apache Beam. Here, we use dummy stage numbers ("steps") as the input and output PCollections needed to work with Beam's programming model. Where substantive inputs need to be mapped to stages with arguments, "mappables" are combined with these steps. The result is that each stage executes serially, and mappable stages execute in parallel.

Fixes #169.