### PR TITLE
Add marks to executors to allow selection and parallelization

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -65,18 +65,18 @@ jobs:
         pytest-mark: ["no_executor", "executor_python", "executor_dask", "executor_prefect", "executor_prefect_dask"]
     steps:
       - uses: actions/checkout@v2
-      - name: 🔁 Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: x64
-      - name: 🔁 Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          activate-environment: pangeo-forge-recipes
-          use-mamba: true
+      # - name: 🔁 Setup Python
+      #   uses: actions/setup-python@v2
+      #   with:
+      #     python-version: ${{ matrix.python-version }}
+      #     architecture: x64
+      # - name: 🔁 Setup Miniconda
+      #   uses: conda-incubator/setup-miniconda@v2
+      #   with:
+      #     miniforge-variant: Mambaforge
+      #     miniforge-version: latest
+      #     activate-environment: pangeo-forge-recipes
+      #     use-mamba: true
       - name: 🎯 Set cache number
         id: cache-number
         # cache will last 3 days by default
@@ -93,6 +93,8 @@ jobs:
       - name: 🤿  Bail out if no cache hit
         if: steps.conda-cache.outputs.cache-hit != 'true'
         run: false
+      - name: 🎯 Set path to include conda python
+        run: echo "/usr/share/miniconda3/envs/pangeo-forge-recipes/bin" >> $GITHUB_PATH
       - name: 🌈 Install pangeo-forge-recipes package
         shell: bash -l {0}
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,6 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9]
+        pytest-mark: ["no_executor", "executor_python", "executor_dask", "executor_prefect", "executor_prefect_dask"]
     steps:
       - uses: actions/checkout@v2
       - name: 🔁 Setup Python
@@ -99,7 +100,7 @@ jobs:
       - name: 🏄‍♂️ Run Tests
         shell: bash -l {0}
         run: |
-          py.test tests -v --redirect-dask-worker-logs-to-stdout=DEBUG \
+          py.test tests -v -m ${{ matrix.pytest-mark }} \
             --cov=pangeo_forge_recipes --cov-config .coveragerc \
             --cov-report term-missing \
             --cov-report xml \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,6 +13,37 @@ on:
 env:
   PYTEST_ADDOPTS: "--color=yes"
 
+# This is a pretty complicated workflow. The reason it is this way is that it
+# has been optimized to go fast fast. The specific optimizations are
+#
+# ## Environment building and caching ("prepare-env" job)
+#
+#    This step builds and caches the test environments using conda.
+#    If there is no cache, building each environment takes 3-4 minutes.
+#    If there is a cache this step should take about 40 seconds.
+#    (The time needed to install conda and check the cache.)
+#
+#    The cache key is as follows:
+#    ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles( env.env_file ) }}-${{ env.CACHE_NUMBER }}
+#
+#    A key parameter env.CACHE_NUMBER. This is a number that is set based on the current date:
+#    CACHE_NUMBER=`expr $(date +'%j') / 3`
+#    This is designed such that the cached environment will be reused for maximum 3 days.
+#    After 3 days, the CACHE_NUMBER will increment, forcing a new environment to be built.
+#    This cadence was chosen as a balance between making the tests go fast
+#    (avoiding rebuilding environments every run), and using a fresh, recent environment.
+#
+#    The test environment is cached in /usr/share/miniconda3/envs/pangeo-forge-recipes
+#
+# ## Running the tests ("run-tests" job)
+#
+#    This step does not even attempt to build environments. It just loads them from the cache.
+#    Then it adds the following path to $PATH
+#    /usr/share/miniconda3/envs/pangeo-forge-recipes/bin
+#
+#    We use pytest marks to parallelize execution across the different executors.
+#    These marks are configured in tests/conftest.py
+
 jobs:
   prepare-env:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -65,18 +65,6 @@ jobs:
         pytest-mark: ["no_executor", "executor_python", "executor_dask", "executor_prefect", "executor_prefect_dask"]
     steps:
       - uses: actions/checkout@v2
-      # - name: 🔁 Setup Python
-      #   uses: actions/setup-python@v2
-      #   with:
-      #     python-version: ${{ matrix.python-version }}
-      #     architecture: x64
-      # - name: 🔁 Setup Miniconda
-      #   uses: conda-incubator/setup-miniconda@v2
-      #   with:
-      #     miniforge-variant: Mambaforge
-      #     miniforge-version: latest
-      #     activate-environment: pangeo-forge-recipes
-      #     use-mamba: true
       - name: 🎯 Set cache number
         id: cache-number
         # cache will last 3 days by default

--- a/docs/development/development_guide.md
+++ b/docs/development/development_guide.md
@@ -99,6 +99,19 @@ py.test tests -v --redirect-dask-worker-logs-to-stdout=DEBUG
 
 These can be useful in debugging.
 
+#### Custom Markers
+
+The test suite is configured with a custom set of [pytest markers](https://docs.pytest.org/en/latest/example/markers.htm).
+These can be used to select specific executors to test.
+This feature is used in the [main test Github Workfow](https://github.com/pangeo-forge/pangeo-forge-recipes/blob/master/.github/workflows/main.yaml).
+These marks are enumerated in [setup.cfg](https://github.com/pangeo-forge/pangeo-forge-recipes/blob/master/setup.cfg).
+
+For example, to run just the test that use the Dask executor, you can do
+
+```bash
+py.test tests -m executor_dask
+```
+
 ### Submit a Pull Request
 
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/pangeo-forge/pangeo-forge-recipes?style=flat-square)](https://github.com/pangeo-forge/pangeo-forge-recipes/pulls)
@@ -130,6 +143,24 @@ When you are ready to make changes.
   git branch -d my-cool-feature
   ```
 
+### Continuous Integration
+
+Continuous integration is done with [GitHub Actions](https://docs.github.com/en/actions/learn-github-actions).
+
+There are currently 5 workflows configured:
+
+- [pre-commit.yaml](https://github.com/pangeo-forge/pangeo-forge-recipes/blob/master/.github/workflows/pre-commit.yaml) -
+  Code linting.
+- [main.yaml](https://github.com/pangeo-forge/pangeo-forge-recipes/blob/master/.github/workflows/main.yaml) -
+  Run test suite with pytest.
+- [slash-command-dispatch.yaml](https://github.com/pangeo-forge/pangeo-forge-recipes/blob/master/.github/workflows/slash-command-dispatch.yaml) and [tutorials.yaml](https://github.com/pangeo-forge/pangeo-forge-recipes/blob/master/.github/workflows/tutorials.yaml) -
+  These workflows collaborate to enable the slash-command `/run-test-tutorials` to be run
+  via a comment on a PR. This enables us to check whether the PR breaks any of our tutorials.
+  We don't run the tutorials as part of regular CI because they are very slow.
+  (However, the tutorial workflow _is_ run on commits to the `master` branch.)
+- [release.yaml](https://github.com/pangeo-forge/pangeo-forge-recipes/blob/master/.github/workflows/release.yaml) -
+  This workflow generates a pypi release every time a GitHub release is created.
+
 ## Contributing to the Documentation
 
 We strongly encourage contributions to make the documentation clearer and more complete.
@@ -153,3 +184,10 @@ Serving the documentation locally (staring from the `docs` directory)
 cd _build/html; python -m http.server; cd ../..
 # press ctrl-C to exit
 ```
+
+## Releasing
+
+To make a new release, just go to <https://github.com/pangeo-forge/pangeo-forge-recipes/releases>
+and click "Draft a new release".
+The [release.yaml](https://github.com/pangeo-forge/pangeo-forge-recipes/blob/master/.github/workflows/release.yaml) -
+workflow should take care of the rest.

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,12 @@ line_length=100
 log_cli = False
 timeout = 30
 timeout_method = signal
+markers =
+    no_executor: Tests that do not use an executor fixture.
+    executor_python: Tests that use the Python executor.
+    executor_dask: Tests that use the Dask executor.
+    executor_prefect: Tests that use the Prefect executor.
+    executor_prefect_dask: Tests that use the Prefect executor with a Dask cluster.
 
 # remove this once rechunker executors are factored into a standalone package
 # that exports type hints (https://mypy.readthedocs.io/en/latest/installed_packages.html#installed-packages)


### PR DESCRIPTION
Hopefully this will make our test suite go a lot faster by parallelizing execution across the different executors.