### PR TITLE
Prevent operator fusion for every stage of the Beam executor.

### DIFF
--- a/pangeo_forge_recipes/executors/beam.py
+++ b/pangeo_forge_recipes/executors/beam.py
@@ -70,6 +70,7 @@ class BeamPipelineExecutor(PipelineExecutor[beam.PTransform]):
                 pcoll |= stage.name >> beam.Map(
                     _no_arg_stage, current=step, fun=stage.function, config=pipeline.config
                 )
+            pcoll |= f"Reshuffle{step:03d}" >> beam.Reshuffle()
 
         return pcoll
 


### PR DESCRIPTION
In an end-to-end experiment, I noticed that stages were still being fused. This caused errors to occur, namely that the Zarr metadata file was not created before one of the later steps (I think `store_chunk`) that needed it.

By adding a `beam.Reshuffle()` step to the end of every stage, we ensure that fusion doesn't occur and that stages do execute serially.