### PR TITLE
Add upstream dev matrix to tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -106,7 +106,11 @@ jobs:
           - python-version: 3.9
             pytest-mark: "executor_beam"
           - dependencies: "upstream-dev"
-            pytest-mark: ["no_executor", "executor_function", "executor_generator"]
+            pytest-mark: "no_executor"
+          - dependencies: "upstream-dev"
+            pytest-mark: "executor_function"
+          - dependencies: "upstream-dev"
+            pytest-mark: "executor_generator"
     steps:
       - uses: actions/checkout@v2
       - name: 🎯 Set cache number

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9]
-        use-upstream-dev: [true, false]
+        use-upstream-dev: ['true', 'false']
     steps:
       - uses: actions/checkout@v2
       - name: 🔁 Setup Python

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -93,7 +93,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9]
-        use-upstream-dev: [true, false]
+        dependencies: ["releases-only", "upstream-dev"]
         pytest-mark: ["no_executor", "executor_function", "executor_generator",
                       "executor_dask", "executor_prefect", "executor_prefect_dask",
                       "executor_beam"]
@@ -122,8 +122,10 @@ jobs:
       - name: 🎯 Set path to include conda python
         run: echo "/usr/share/miniconda3/envs/pangeo-forge-recipes/bin" >> $GITHUB_PATH
       - name: 🧑‍💻 Maybe use upstream dev versions
-        if: matrix.use-upstream-dev == 'true'
-        run: mamba env update -n pangeo-forge-recipes -f ci/upstream-dev.yml
+        if: matrix.dependencies == 'upstream-dev'
+        run: |
+          mamba env update -n pangeo-forge-recipes -f ci/upstream-dev.yml \
+          && conda list
       - name: 🌈 Install pangeo-forge-recipes package
         shell: bash -l {0}
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -106,8 +106,6 @@ jobs:
           - python-version: 3.9
             pytest-mark: "executor_beam"
           - dependencies: "upstream-dev"
-            pytest-mark: "no_executor"
-          - dependencies: "upstream-dev"
             pytest-mark: "executor_function"
           - dependencies: "upstream-dev"
             pytest-mark: "executor_generator"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,6 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9]
+        use-upstream-dev: [true, false]
     steps:
       - uses: actions/checkout@v2
       - name: 🔁 Setup Python
@@ -81,6 +82,9 @@ jobs:
       - name: 🐫 Maybe Update environment
         if: steps.conda-cache.outputs.cache-hit != 'true'
         run: mamba env update -n pangeo-forge-recipes -f ${{ env.env_file }}
+      - name: 🧑‍💻 Maybe use upstream dev versions
+        if: ${{ matrix.use-upstream-dev }} == 'true'
+        run: mamba env update -n pangeo-forge-recipes -f ci/upstream-dev.yml
       - name: 🐍 List conda env
         shell: bash -l {0}
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: 🐫 Maybe Update environment
         if: steps.conda-cache.outputs.cache-hit != 'true'
         run: mamba env update -n pangeo-forge-recipes -f ${{ env.env_file }}
-      - name: 🧑‍💻 If not 'releases-only' job, always update upstream dev versions
+      - name: 🧑‍💻 Maybe update to upstream dev versions
         if: matrix.dependencies == 'upstream-dev'
         run: mamba env update -n pangeo-forge-recipes -f ci/upstream-dev.yml
       - name: 🐍 List conda env

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -124,7 +124,8 @@ jobs:
       - name: 🧑‍💻 Maybe use upstream dev versions
         if: matrix.dependencies == 'upstream-dev'
         run: |
-          mamba env update -n pangeo-forge-recipes -f ci/upstream-dev.yml \
+          conda install mamba -n pangeo-forge-recipes -c conda-forge -y \
+          && mamba env update -n pangeo-forge-recipes -f ci/upstream-dev.yml \
           && conda list
       - name: 🌈 Install pangeo-forge-recipes package
         shell: bash -l {0}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,6 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9]
+        dependencies: ["releases-only", "upstream-dev"]
     steps:
       - uses: actions/checkout@v2
       - name: 🔁 Setup Python
@@ -76,11 +77,14 @@ jobs:
         name: 🗃 Cache environment
         with:
           path: /usr/share/miniconda3/envs/pangeo-forge-recipes
-          key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles( env.env_file ) }}-${{ env.CACHE_NUMBER }}
+          key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles( env.env_file ) }}-${{ matrix.dependencies }}-${{ env.CACHE_NUMBER }}
         id: conda-cache
       - name: 🐫 Maybe Update environment
         if: steps.conda-cache.outputs.cache-hit != 'true'
         run: mamba env update -n pangeo-forge-recipes -f ${{ env.env_file }}
+      - name: 🧑‍💻 If not 'releases-only' job, always update upstream dev versions
+        if: matrix.dependencies == 'upstream-dev'
+        run: mamba env update -n pangeo-forge-recipes -f ci/upstream-dev.yml
       - name: 🐍 List conda env
         shell: bash -l {0}
         run: |
@@ -114,19 +118,13 @@ jobs:
         name: 🗃 Loaded Cached environment
         with:
           path: /usr/share/miniconda3/envs/pangeo-forge-recipes
-          key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles( env.env_file ) }}-${{ env.CACHE_NUMBER }}
+          key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles( env.env_file ) }}-${{ matrix.dependencies }}-${{ env.CACHE_NUMBER }}
         id: conda-cache
       - name: 🤿  Bail out if no cache hit
         if: steps.conda-cache.outputs.cache-hit != 'true'
         run: false
       - name: 🎯 Set path to include conda python
         run: echo "/usr/share/miniconda3/envs/pangeo-forge-recipes/bin" >> $GITHUB_PATH
-      - name: 🧑‍💻 Maybe use upstream dev versions
-        if: matrix.dependencies == 'upstream-dev'
-        run: |
-          conda install mamba -n pangeo-forge-recipes -c conda-forge -y \
-          && mamba env update -n pangeo-forge-recipes -f ci/upstream-dev.yml \
-          && conda list
       - name: 🌈 Install pangeo-forge-recipes package
         shell: bash -l {0}
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,7 +51,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9]
-        use-upstream-dev: ['true', 'false']
     steps:
       - uses: actions/checkout@v2
       - name: 🔁 Setup Python
@@ -82,9 +81,6 @@ jobs:
       - name: 🐫 Maybe Update environment
         if: steps.conda-cache.outputs.cache-hit != 'true'
         run: mamba env update -n pangeo-forge-recipes -f ${{ env.env_file }}
-      - name: 🧑‍💻 Maybe use upstream dev versions
-        if: ${{ matrix.use-upstream-dev }} == 'true'
-        run: mamba env update -n pangeo-forge-recipes -f ci/upstream-dev.yml
       - name: 🐍 List conda env
         shell: bash -l {0}
         run: |
@@ -97,6 +93,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9]
+        use-upstream-dev: [true, false]
         pytest-mark: ["no_executor", "executor_function", "executor_generator",
                       "executor_dask", "executor_prefect", "executor_prefect_dask",
                       "executor_beam"]
@@ -124,6 +121,9 @@ jobs:
         run: false
       - name: 🎯 Set path to include conda python
         run: echo "/usr/share/miniconda3/envs/pangeo-forge-recipes/bin" >> $GITHUB_PATH
+      - name: 🧑‍💻 Maybe use upstream dev versions
+        if: matrix.use-upstream-dev == 'true'
+        run: mamba env update -n pangeo-forge-recipes -f ci/upstream-dev.yml
       - name: 🌈 Install pangeo-forge-recipes package
         shell: bash -l {0}
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -105,6 +105,8 @@ jobs:
           # No beam support in python 3.9
           - python-version: 3.9
             pytest-mark: "executor_beam"
+          - dependencies: "upstream-dev"
+            pytest-mark: ["no_executor", "executor_function", "executor_generator"]
     steps:
       - uses: actions/checkout@v2
       - name: 🎯 Set cache number

--- a/ci/upstream-dev.yml
+++ b/ci/upstream-dev.yml
@@ -1,0 +1,8 @@
+name: pangeo-forge-recipes
+channels:
+  - conda-forge
+dependencies:
+  - pip:
+    - "git+https://github.com/dask/dask.git"
+    - "git+https://github.com/fsspec/filesystem_spec.git"
+    - "git+https://github.com/pydata/xarray.git"

--- a/ci/upstream-dev.yml
+++ b/ci/upstream-dev.yml
@@ -5,4 +5,5 @@ dependencies:
   - pip:
     - "git+https://github.com/dask/dask.git"
     - "git+https://github.com/fsspec/filesystem_spec.git"
+    - "git+https://github.com/PrefectHQ/prefect.git"
     - "git+https://github.com/pydata/xarray.git"

--- a/ci/upstream-dev.yml
+++ b/ci/upstream-dev.yml
@@ -1,7 +1,7 @@
 name: pangeo-forge-recipes
-channels:
-  - conda-forge
+
 dependencies:
+  - pip
   - pip:
     - "git+https://github.com/dask/dask.git"
     - "git+https://github.com/fsspec/filesystem_spec.git"


### PR DESCRIPTION
Closes #248

Here's an idea for how this might work.

This PR uses a single `upstream-dev.yml` file to amend the existing CI environments to patch each of them with dev versions for the selected packages. (I'm pretty sure this update style works.) It doesn't cache these patched environments (which I think makes sense, as they'll be updating so frequently).