### PR TITLE
Improving the error message of `calculate_sequence_lens` in the `prepare_targets` step.

### DIFF
--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -393,7 +393,9 @@ def calculate_sequence_lens(
     if len(all_lens.shape) == 1:
         all_lens = np.expand_dims(all_lens, 1)
 
+    # check that all lens are the same along the concat dim
     unique_vec, unique_idx = np.unique(all_lens, axis=1, return_index=True)
+
     if len(unique_idx) > 1:
         correct_col = all_lens[:, unique_idx[0]]
         err_idx = np.where(np.expand_dims(correct_col, 1) != all_lens)

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -396,8 +396,8 @@ def calculate_sequence_lens(
 
     unique_vec, unique_idx = np.unique(all_lens, axis=1, return_index=True)
     if len(unique_idx) > 1:
-        modes = np.apply_along_axis(statistics.mode, 1, all_lens)
-        err_idx = np.where(np.expand_dims(modes, 1) != all_lens)
+        correct_col = all_lens[:, unique_idx[0]]
+        err_idx = np.where(np.expand_dims(correct_col, 1) != all_lens)
         err_pos = list(zip(*err_idx[::-1]))
         raise ValueError(
             f"Inconsistent sequence lengths between indicies {unique_idx} of the concat dim."

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import itertools
 import logging
 import os
-import statistics
 import warnings
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field, replace

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -394,10 +394,10 @@ def calculate_sequence_lens(
         all_lens = np.expand_dims(all_lens, 1)
 
     # check that all lens are the same along the concat dim
-    unique_vec, unique_idx = np.unique(all_lens, axis=1, return_index=True)
+    unique_vec, unique_idx, unique_counts = np.unique(all_lens, axis=1, return_index=True, return_counts=True)
 
     if len(unique_idx) > 1:
-        correct_col = all_lens[:, unique_idx[0]]
+        correct_col = all_lens[:, unique_idx[np.argmax(unique_counts)]]
         err_idx = np.where(np.expand_dims(correct_col, 1) != all_lens)
         err_pos = list(zip(*err_idx[::-1]))
         raise ValueError(

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -402,14 +402,18 @@ def calculate_sequence_lens(
         all_lens = np.expand_dims(all_lens, 1)
 
     # check that all lens are the same along the concat dim
-    unique_vec, unique_idx, unique_counts = np.unique(all_lens, axis=1, return_index=True, return_counts=True)
+    unique_vec, unique_idx, unique_counts = np.unique(
+        all_lens, axis=1, return_index=True, return_counts=True
+    )
 
     if len(unique_idx) > 1:
         correct_col = all_lens[:, unique_idx[np.argmax(unique_counts)]]
         err_idx = np.where(np.expand_dims(correct_col, 1) != all_lens)
         err_pos = list(zip(*err_idx))
         # present a list of problematic files to the user, given the file pattern.
-        file_list = '\n'.join([f"- {_get_fname_from_error_pos(epos, file_pattern)!r}" for epos in err_pos])
+        file_list = "\n".join(
+            [f"- {_get_fname_from_error_pos(epos, file_pattern)!r}" for epos in err_pos]
+        )
         raise ValueError(
             f"Inconsistent sequence lengths between indices {unique_idx} of the concat dim."
             f"\nValue(s) {all_lens[err_idx]} at position(s) {err_pos} are different from the rest."

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -362,11 +362,11 @@ def open_chunk(chunk_key: ChunkKey, *, config: XarrayZarrRecipe) -> xr.Dataset:
         yield ds
 
 
-def get_input_meta(metadata_cache: Optional[MetadataTarget], *input_keys: InputKey,) -> Dict:
+def get_input_meta(metadata_cache: Optional[MetadataTarget], file_pattern: FilePattern,) -> Dict:
     # getitems should be async; much faster than serial calls
     if metadata_cache is None:
         raise ValueError("metadata_cache is not set.")
-    return metadata_cache.getitems([_input_metadata_fname(k) for k in input_keys])
+    return metadata_cache.getitems([_input_metadata_fname(k) for k in file_pattern])
 
 
 def calculate_sequence_lens(
@@ -384,8 +384,7 @@ def calculate_sequence_lens(
 
     # read per-input metadata; this is distinct from global metadata
     # get the sequence length of every file
-    # this line could become problematic for large (> 10_000) lists of files
-    input_meta = get_input_meta(metadata_cache, *file_pattern)
+    input_meta = get_input_meta(metadata_cache, file_pattern)
     # use a numpy array to allow reshaping
     all_lens = np.array([m["dims"][concat_dim] for m in input_meta.values()])
     all_lens.shape = list(file_pattern.dims.values())

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -401,7 +401,7 @@ def calculate_sequence_lens(
         err_idx = np.where(np.expand_dims(correct_col, 1) != all_lens)
         err_pos = list(zip(*err_idx[::-1]))
         raise ValueError(
-            f"Inconsistent sequence lengths between indicies {unique_idx} of the concat dim."
+            f"Inconsistent sequence lengths between indices {unique_idx} of the concat dim."
             f"\nValue(s) {all_lens[err_idx]} at position(s) {err_pos} are different from the rest."
             f"\n{all_lens}"
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ max-line-length = 100
 
 [isort]
 known_first_party=pangeo_forge_recipes
-known_third_party=aiohttp,apache_beam,click,dask,fsspec,fsspec_reference_maker,mypy_extensions,numpy,pandas,prefect,pytest,pytest_lazyfixture,scipy,setuptools,xarray,yaml,zarr
+known_third_party=aiohttp,apache_beam,click,dask,fsspec,fsspec_reference_maker,mypy_extensions,numpy,pandas,prefect,pytest,pytest_lazyfixture,setuptools,xarray,yaml,zarr
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ max-line-length = 100
 
 [isort]
 known_first_party=pangeo_forge_recipes
-known_third_party=aiohttp,apache_beam,click,dask,fsspec,fsspec_reference_maker,mypy_extensions,numpy,pandas,prefect,pytest,pytest_lazyfixture,setuptools,xarray,yaml,zarr
+known_third_party=aiohttp,apache_beam,click,dask,fsspec,fsspec_reference_maker,mypy_extensions,numpy,pandas,prefect,pytest,pytest_lazyfixture,scipy,setuptools,xarray,yaml,zarr
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/tests/recipe_tests/test_XarrayZarrRecipe.py
+++ b/tests/recipe_tests/test_XarrayZarrRecipe.py
@@ -462,7 +462,7 @@ def test_calculate_sequence_length(calc_sequence_length_fixture):
 
 def test_calc_sequence_length_errors_no_metadata():
     file_pattern = FilePattern(
-        lambda time, var: f"tmp/{time.date()!s}_{var}",
+        lambda time, variable: f"tmp/{time.date()!s}_{variable}",
         ConcatDim("time", [datetime.datetime(year=2021, month=1, day=d) for d in range(1, 11)]),
         MergeDim("variable", ["foo", "bar"]),
     )
@@ -472,7 +472,7 @@ def test_calc_sequence_length_errors_no_metadata():
 
 def test_calc_sequence_length_errors_inconsistent_lengths(tmp_metadata_target, monkeypatch):
     file_pattern = FilePattern(
-        lambda time, var: f"tmp/{time.date()!s}_{var}",
+        lambda time, variable: f"tmp/{time.date()!s}_{variable}",
         ConcatDim("time", [datetime.datetime(year=2021, month=1, day=d) for d in range(1, 5)]),
         MergeDim("variable", ["foo", "bar", "baz"]),
     )
@@ -492,14 +492,15 @@ def test_calc_sequence_length_errors_inconsistent_lengths(tmp_metadata_target, m
 
     msg = execinfo.value.args[0]
     assert "Inconsistent sequence lengths between indices [1 0] of the concat dim." in msg
-    assert "Value(s) [7] at position(s) [(0, 2)] are different from the rest." in msg
+    assert "Value(s) [7] at position(s) [(2, 0)] are different from the rest." in msg
+    assert "- 'tmp/2021-01-03_foo'" in msg
 
 
 def test_calc_sequence_length_errors_multiple_inconsistent_lengths(
     tmp_metadata_target, monkeypatch
 ):
     file_pattern = FilePattern(
-        lambda time, var: f"tmp/{time.date()!s}_{var}",
+        lambda time, variable: f"tmp/{time.date()!s}_{variable}",
         ConcatDim("time", [datetime.datetime(year=2021, month=1, day=d) for d in range(1, 5)]),
         MergeDim("variable", ["foo", "bar", "baz"]),
     )
@@ -519,14 +520,16 @@ def test_calc_sequence_length_errors_multiple_inconsistent_lengths(
 
     msg = execinfo.value.args[0]
     assert "Inconsistent sequence lengths between indices [1 2 0] of the concat dim." in msg
-    assert "Value(s) [ 7 10] at position(s) [(0, 2), (2, 3)] are different from the rest." in msg
+    assert "Value(s) [ 7 10] at position(s) [(2, 0), (3, 2)] are different from the rest." in msg
+    assert "- 'tmp/2021-01-03_foo'" in msg
+    assert "- 'tmp/2021-01-04_baz'" in msg
 
 
 def test_calc_sequence_length_errors_inconsistent_lengths_reverse_combine_dim_order(
     tmp_metadata_target, monkeypatch
 ):
     file_pattern = FilePattern(
-        lambda var, time: f"tmp/{time.date()!s}_{var}",
+        lambda variable, time: f"tmp/{time.date()!s}_{variable}",
         MergeDim("variable", ["foo", "bar", "baz"]),
         ConcatDim("time", [datetime.datetime(year=2021, month=1, day=d) for d in range(1, 5)]),
     )
@@ -545,4 +548,5 @@ def test_calc_sequence_length_errors_inconsistent_lengths_reverse_combine_dim_or
 
     msg = execinfo.value.args[0]
     assert "Inconsistent sequence lengths between indices [0 3] of the concat dim." in msg
-    assert "Value(s) [5] at position(s) [(3, 1)] are different from the rest." in msg
+    assert "Value(s) [5] at position(s) [(1, 3)] are different from the rest." in msg
+    assert "- 'tmp/2021-01-04_bar'" in msg

--- a/tests/recipe_tests/test_XarrayZarrRecipe.py
+++ b/tests/recipe_tests/test_XarrayZarrRecipe.py
@@ -491,7 +491,7 @@ def test_calc_sequence_length_errors_inconsistent_lengths(tmp_metadata_target, m
         calculate_sequence_lens(None, file_pattern, tmp_metadata_target)
 
     msg = execinfo.value.args[0]
-    assert "Inconsistent sequence lengths between indicies [1 0] of the concat dim." in msg
+    assert "Inconsistent sequence lengths between indices [1 0] of the concat dim." in msg
     assert "Value(s) [7] at position(s) [(0, 2)] are different from the rest." in msg
 
 
@@ -518,7 +518,7 @@ def test_calc_sequence_length_errors_multiple_inconsistent_lengths(
         calculate_sequence_lens(None, file_pattern, tmp_metadata_target)
 
     msg = execinfo.value.args[0]
-    assert "Inconsistent sequence lengths between indicies [1 2 0] of the concat dim." in msg
+    assert "Inconsistent sequence lengths between indices [1 2 0] of the concat dim." in msg
     assert "Value(s) [ 7 10] at position(s) [(0, 2), (2, 3)] are different from the rest." in msg
 
 
@@ -544,5 +544,5 @@ def test_calc_sequence_length_errors_inconsistent_lengths_reverse_combine_dim_or
         calculate_sequence_lens(None, file_pattern, tmp_metadata_target)
 
     msg = execinfo.value.args[0]
-    assert "Inconsistent sequence lengths between indicies [0 3] of the concat dim." in msg
+    assert "Inconsistent sequence lengths between indices [0 3] of the concat dim." in msg
     assert "Value(s) [5] at position(s) [(3, 1)] are different from the rest." in msg

--- a/tests/recipe_tests/test_XarrayZarrRecipe.py
+++ b/tests/recipe_tests/test_XarrayZarrRecipe.py
@@ -487,15 +487,12 @@ def test_calc_sequence_length_errors_inconsistent_lengths(tmp_metadata_target, m
 
     monkeypatch.setattr(MetadataTarget, "getitems", mock_getitems)
 
-    with pytest.raises(
-        ValueError, match="Inconsistent sequence lengths between indicies"
-    ) as execinfo:
+    with pytest.raises(ValueError) as execinfo:
         calculate_sequence_lens(None, file_pattern, tmp_metadata_target)
 
     msg = execinfo.value.args[0]
-    assert "[1 0]" in msg
-    assert "[7]" in msg
-    assert "[(0, 2)]" in msg
+    assert "Inconsistent sequence lengths between indicies [1 0] of the concat dim." in msg
+    assert "Value(s) [7] at position(s) [(0, 2)] are different from the rest." in msg
 
 
 def test_calc_sequence_length_errors_multiple_inconsistent_lengths(
@@ -517,15 +514,12 @@ def test_calc_sequence_length_errors_multiple_inconsistent_lengths(
 
     monkeypatch.setattr(MetadataTarget, "getitems", mock_getitems)
 
-    with pytest.raises(
-        ValueError, match="Inconsistent sequence lengths between indicies"
-    ) as execinfo:
+    with pytest.raises(ValueError) as execinfo:
         calculate_sequence_lens(None, file_pattern, tmp_metadata_target)
 
     msg = execinfo.value.args[0]
-    assert "[1 2 0]" in msg
-    assert "[ 7 10]" in msg
-    assert "[(0, 2), (2, 3)]" in msg
+    assert "Inconsistent sequence lengths between indicies [1 2 0] of the concat dim." in msg
+    assert "Value(s) [ 7 10] at position(s) [(0, 2), (2, 3)] are different from the rest." in msg
 
 
 def test_calc_sequence_length_errors_inconsistent_lengths_reverse_combine_dim_order(
@@ -546,12 +540,9 @@ def test_calc_sequence_length_errors_inconsistent_lengths_reverse_combine_dim_or
 
     monkeypatch.setattr(MetadataTarget, "getitems", mock_getitems)
 
-    with pytest.raises(
-        ValueError, match="Inconsistent sequence lengths between indicies"
-    ) as execinfo:
+    with pytest.raises(ValueError) as execinfo:
         calculate_sequence_lens(None, file_pattern, tmp_metadata_target)
 
     msg = execinfo.value.args[0]
-    assert "[0 3]" in msg
-    assert "[5]" in msg
-    assert "[(3, 1)]" in msg
+    assert "Inconsistent sequence lengths between indicies [0 3] of the concat dim." in msg
+    assert "Value(s) [5] at position(s) [(3, 1)] are different from the rest." in msg

--- a/tests/recipe_tests/test_XarrayZarrRecipe.py
+++ b/tests/recipe_tests/test_XarrayZarrRecipe.py
@@ -509,8 +509,10 @@ def test_calc_sequence_length_errors_multiple_inconsistent_lengths(
         return {
             "a": {"dims": {"time": [1] * 3, "variables": []}},
             "b": {"dims": {"time": [2] * 3, "variables": []}},
-            "c": {"dims": {"time": [7] + [3] * 2, "variables": []}},   # Inconsistent sequence length
-            "d": {"dims": {"time": [4] * 2 + [10], "variables": []}},  # Inconsistent sequence length
+            "c": {"dims": {"time": [7] + [3] * 2, "variables": []}},  # Inconsistent sequence length
+            "d": {
+                "dims": {"time": [4] * 2 + [10], "variables": []}
+            },  # Inconsistent sequence length
         }
 
     monkeypatch.setattr(MetadataTarget, "getitems", mock_getitems)

--- a/tests/recipe_tests/test_XarrayZarrRecipe.py
+++ b/tests/recipe_tests/test_XarrayZarrRecipe.py
@@ -508,8 +508,8 @@ def test_calc_sequence_length_errors_multiple_inconsistent_lengths(
         return {
             "a": {"dims": {"time": [1] * 3, "variables": []}},
             "b": {"dims": {"time": [2] * 3, "variables": []}},
-            "c": {"dims": {"time": [7] + [3] * 2, "variables": []}},  # Inconsistent sequence length
-            "d": {"dims": {"time": [4] * 2 + [10], "variables": []}},
+            "c": {"dims": {"time": [7] + [3] * 2, "variables": []}},   # Inconsistent sequence length
+            "d": {"dims": {"time": [4] * 2 + [10], "variables": []}},  # Inconsistent sequence length
         }
 
     monkeypatch.setattr(MetadataTarget, "getitems", mock_getitems)


### PR DESCRIPTION
I've re-implemented some of the logic of `calculate_sequence_lengths` to be more readable and to provide the user with a better error message. My intention is to provide enough information to the user that they can identify data errors during the `prepare_targets` step of the Xarray --> Zarr conversion.

The new error message now presents the user the problematic indices along the concat dimension, the erroneous values in question and their location. 

Fixes #253.
