### PR TITLE
Avoid costly `set(group)` operation in finalize_target.

### DIFF
--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -555,7 +555,7 @@ def finalize_target(*, config: XarrayZarrRecipe) -> None:
         # https://github.com/pangeo-forge/pangeo-forge-recipes/issues/214
         # intersect the dims from the array metadata with the Zarr group
         # to handle coordinateless dimensions.
-        dims = set(_gather_coordinate_dimensions(group)) & set(group)
+        dims = {dim for dim in _gather_coordinate_dimensions(group) if dim in group}
         for dim in dims:
             arr = group[dim]
             attrs = dict(arr.attrs)

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -553,7 +553,7 @@ def finalize_target(*, config: XarrayZarrRecipe) -> None:
         target_mapper = config.target.get_mapper()
         group = zarr.open(target_mapper, mode="a")
         # https://github.com/pangeo-forge/pangeo-forge-recipes/issues/214
-        # intersect the dims from the array metadata with the Zarr group
+        # filter out the dims from the array metadata not in the Zarr group
         # to handle coordinateless dimensions.
         dims = (dim for dim in _gather_coordinate_dimensions(group) if dim in group)
         for dim in dims:

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -555,7 +555,7 @@ def finalize_target(*, config: XarrayZarrRecipe) -> None:
         # https://github.com/pangeo-forge/pangeo-forge-recipes/issues/214
         # intersect the dims from the array metadata with the Zarr group
         # to handle coordinateless dimensions.
-        dims = {dim for dim in _gather_coordinate_dimensions(group) if dim in group}
+        dims = (dim for dim in _gather_coordinate_dimensions(group) if dim in group)
         for dim in dims:
             arr = group[dim]
             attrs = dict(arr.attrs)


### PR DESCRIPTION
As pointed out in #254, taking a set difference happens to be an expensive operation for large datasets. Specifically, taking `set(group)` lists all files in the bucket, which is currently implemented inefficiently.

In this patch, we find the set intersection with a filter operation. This should be faster since it only checks if a smaller subset of files exists.