### PR TITLE
Pin fsspec s3fs gcsfs to >= 2022.1.0

### DIFF
--- a/ci/py3.8.yml
+++ b/ci/py3.8.yml
@@ -12,8 +12,8 @@ dependencies:
   - codecov
   - dask
   - distributed
-  - fsspec>=2021.6.0
-  - gcsfs
+  - fsspec>=2022.1.0
+  - gcsfs>=2022.1.0
   - h5netcdf
   # can't solve environment; moved to pip
   # - h5py>=3.3.0  - hdf5
@@ -34,7 +34,7 @@ dependencies:
   - rasterio
   - requests
   - rechunker>=0.4.2
-  - s3fs
+  - s3fs>=2022.1.0
   - scipy
   - setuptools
   - toolz

--- a/ci/py3.9.yml
+++ b/ci/py3.9.yml
@@ -11,8 +11,8 @@ dependencies:
   - codecov
   - dask
   - distributed
-  - fsspec>=2021.6.0
-  - gcsfs
+  - fsspec>=2022.1.0
+  - gcsfs>=2022.1.0
   - graphviz  # needed for building tutorial notebooks
   - h5netcdf
   - h5py>=3.3.0
@@ -38,7 +38,7 @@ dependencies:
   - requests
   - rechunker>=0.4.2
   - scipy
-  - s3fs
+  - s3fs>=2022.1.0
   - setuptools
   - toolz
   - xarray>=0.18.0


### PR DESCRIPTION
Hopefully helps with https://github.com/pangeo-forge/pangeo-forge-recipes/issues/249

Follows @martindurant's suggestion in https://github.com/pangeo-forge/pangeo-forge-recipes/issues/249#issuecomment-982668328 (which was made prior to the release of `2022.1.0`; I figured the latest versions couldn't hurt).

Will try the slash command now to see if it solves the tutorial notebook problem discussed in the linked issue.