### PR TITLE
Add `.assign_temporary_storage` method via `TemporaryStorageMixin`

### DIFF
--- a/pangeo_forge_recipes/recipes/reference_hdf_zarr.py
+++ b/pangeo_forge_recipes/recipes/reference_hdf_zarr.py
@@ -13,7 +13,7 @@ from ..executors.base import Pipeline, Stage
 from ..patterns import Index
 from ..reference import create_hdf5_reference, unstrip_protocol
 from ..storage import FSSpecTarget, MetadataTarget, file_opener
-from .base import BaseRecipe, FilePatternMixin
+from .base import BaseRecipe, FilePatternMixin, TemporaryStorageMixin
 
 ChunkKey = Index
 
@@ -101,7 +101,7 @@ def hdf_reference_recipe_compiler(recipe: HDFReferenceRecipe) -> Pipeline:
 
 
 @dataclass
-class HDFReferenceRecipe(BaseRecipe, FilePatternMixin):
+class HDFReferenceRecipe(BaseRecipe, FilePatternMixin, TemporaryStorageMixin):
     """
     Generates reference files for each input netCDF, then combines
     into one ensemble output

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -25,7 +25,7 @@ from ..patterns import CombineOp, DimIndex, FilePattern, Index
 from ..reference import create_hdf5_reference, unstrip_protocol
 from ..storage import CacheFSSpecTarget, FSSpecTarget, MetadataTarget, file_opener
 from ..utils import calc_subsets, fix_scalar_attr_encoding, lock_for_conflicts
-from .base import BaseRecipe, FilePatternMixin
+from .base import BaseRecipe, FilePatternMixin, TemporaryStorageMixin
 
 # use this filename to store global recipe metadata in the metadata_cache
 # it will be written once (by prepare_target) and read many times (by store_chunk)
@@ -610,7 +610,7 @@ _deprecation_message = (
 
 
 @dataclass
-class XarrayZarrRecipe(BaseRecipe, FilePatternMixin):
+class XarrayZarrRecipe(BaseRecipe, FilePatternMixin, TemporaryStorageMixin):
     """This configuration represents a dataset composed of many individual NetCDF files.
     This class uses Xarray to read and write data and writes its output to Zarr.
     The organization of the source files is described by the ``file_pattern``.

--- a/tests/recipe_tests/test_temp_storage_mixin.py
+++ b/tests/recipe_tests/test_temp_storage_mixin.py
@@ -1,0 +1,34 @@
+import pytest
+
+from pangeo_forge_recipes.recipes.xarray_zarr import XarrayZarrRecipe
+from pangeo_forge_recipes.storage import CacheFSSpecTarget, FSSpecTarget, MetadataTarget
+
+from .test_HDFReferenceRecipe import HDFReferenceRecipe
+
+
+@pytest.fixture(params=[XarrayZarrRecipe, HDFReferenceRecipe])
+def recipe_with_unset_targets(netcdf_local_file_pattern_sequential, request):
+    """Fixture for `test_assign_temp_storage`."""
+
+    RecipeClass = request.param
+    rec = RecipeClass(netcdf_local_file_pattern_sequential)
+
+    targets = {"target": FSSpecTarget, "metadata_cache": MetadataTarget}
+    if isinstance(rec, XarrayZarrRecipe):
+        targets.update({"input_cache": CacheFSSpecTarget})
+
+    return rec, targets
+
+
+def test_assign_temp_storage(recipe_with_unset_targets):
+    """Test `assign_temporary_storage` method inherited from `TemporaryStorageMixin`."""
+
+    rec, targets = recipe_with_unset_targets
+
+    for t in targets:
+        assert getattr(rec, t) is None
+
+    rec.assign_temporary_storage()
+
+    for t, storage_cls in targets.items():
+        assert isinstance(getattr(rec, t), storage_cls)


### PR DESCRIPTION
A lightweight (albeit possibly partial) solution for #276 which is hopefully simple enough to merge (and release) before OSM2022, to aid @rwegener2's ongoing work on https://github.com/pangeo-forge/pangeo-forge-recipes/pull/281.

To achieve the same result as represented by the code block in https://github.com/pangeo-forge/pangeo-forge-recipes/issues/276#issue-1124391211, users would now need only call:

```python
recipe.assign_temporary_storage()
```

I considered setting true defaults (as opposed using the method call), but ultimately thought requiring users to make this method call had some instructive value, insofar as it conveys the notion that storage targets for a given recipe are customizable.

@rabernat, by way of background, Rachel and I believe we need _some type_ of simplification for OSM in this area. I am by no means attached to this particular solution, it simply represents my best effort at something simple enough to merge (and then document!) on our short runway. Totally open to any alternative if you can think of a better one.