### PR TITLE
Add `setup_logging` convenience function

### DIFF
--- a/pangeo_forge_recipes/recipes/__init__.py
+++ b/pangeo_forge_recipes/recipes/__init__.py
@@ -2,3 +2,24 @@ from .reference_hdf_zarr import HDFReferenceRecipe
 from .xarray_zarr import XarrayZarrRecipe
 
 __all__ = ["XarrayZarrRecipe", "HDFReferenceRecipe"]
+
+
+def setup_logging(level: str = "INFO"):
+    """A convenience function that sets up logging for developing and debugging recipes in Jupyter,
+    iPython, or another interactive context.
+
+    :param level: One of (in decreasing level of detail) ``"DEBUG"``, ``"INFO"``, or ``"WARNING"``.
+      Defaults to ``"INFO"``.
+    """
+
+    import logging
+    import sys
+
+    formatter = logging.Formatter("%(name)s - %(levelname)s - %(message)s")
+    logger = logging.getLogger("pangeo_forge_recipes")
+    if logger.hasHandlers():
+        logger.handlers.clear()
+    logger.setLevel(getattr(logging, level))
+    sh = logging.StreamHandler(stream=sys.stdout)
+    sh.setFormatter(formatter)
+    logger.addHandler(sh)

--- a/pangeo_forge_recipes/recipes/__init__.py
+++ b/pangeo_forge_recipes/recipes/__init__.py
@@ -11,15 +11,15 @@ def setup_logging(level: str = "INFO"):
     :param level: One of (in decreasing level of detail) ``"DEBUG"``, ``"INFO"``, or ``"WARNING"``.
       Defaults to ``"INFO"``.
     """
-
     import logging
-    import sys
 
-    formatter = logging.Formatter("%(name)s - %(levelname)s - %(message)s")
+    from rich.logging import RichHandler
+
     logger = logging.getLogger("pangeo_forge_recipes")
     if logger.hasHandlers():
         logger.handlers.clear()
     logger.setLevel(getattr(logging, level))
-    sh = logging.StreamHandler(stream=sys.stdout)
-    sh.setFormatter(formatter)
-    logger.addHandler(sh)
+    handler = RichHandler()
+    formatter = logging.Formatter("%(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)

--- a/pangeo_forge_recipes/recipes/__init__.py
+++ b/pangeo_forge_recipes/recipes/__init__.py
@@ -13,13 +13,19 @@ def setup_logging(level: str = "INFO"):
     """
     import logging
 
-    from rich.logging import RichHandler
+    try:
+        from rich.logging import RichHandler
+
+        handler = RichHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+    except ImportError:
+        import sys
+
+        handler = logging.StreamHandler(stream=sys.stdout)
+        handler.setFormatter(logging.Formatter("%(name)s - %(levelname)s - %(message)s"))
 
     logger = logging.getLogger("pangeo_forge_recipes")
     if logger.hasHandlers():
         logger.handlers.clear()
     logger.setLevel(getattr(logging, level))
-    handler = RichHandler()
-    formatter = logging.Formatter("%(message)s")
-    handler.setFormatter(formatter)
     logger.addHandler(handler)

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ install_requires =
     numcodecs >= 0.9.0
     fsspec[http] >= 2021.6.0
     fsspec-reference-maker >= 0.0.4
-    rich >= 10.16.1
     mypy_extensions
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     numcodecs >= 0.9.0
     fsspec[http] >= 2021.6.0
     fsspec-reference-maker >= 0.0.4
+    rich >= 10.16.1
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
The convenience function added in this PR is a version of the same function we've recommended to users in tutorials, with the addition of the `logger.handlers.clear()` block, which allows the function to be reused during a single interpreter session without duplicating logs.

The addition of this function is specifically motivated to help @rwegener2 with ongoing work on https://github.com/pangeo-forge/pangeo-forge-recipes/pull/281 in advance of OSM2022. Pre-packaging this function hopefully lowers the barrier to entry for new recipe developers by giving them the tools they need to get started with execution debugging out-of-the-box.

I considered various places we might add this function and ultimately settled on `.recipes.__init__` because users will already be importing from that path, so they can now just do:

```python
from pangeo_forge_recipes.recipes import XarrayZarrRecipe, setup_logging
```

Open to alternatives.