### PR TITLE
Move netcdf4 and h5netcdf to required install

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,8 @@ install_requires =
     intake >= 0.6.4
     intake-xarray >= 0.4.1
     xarray >=0.18.0
+    netcdf4
+    h5netcdf
     zarr >= 2.6.0
     numcodecs >= 0.9.0
     fsspec[http] >= 2021.6.0
@@ -47,9 +49,6 @@ dev =
     pytest-cov
     pytest-lazy-fixture
     scipy
-    netcdf4
-    h5netcdf
-    zarr
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This PR addresses an issue in the depenencies surfaced by the `ValueError: unrecognized engine h5netcdf must be one of: ['netcdf4', 'store', 'zarr']`  surfaced in #293  (see "engine error on run"  section of the PR description).
