### PR TITLE
Don't allow chunksize > dimsize in ChunkGrid.from_uniform_grid

### DIFF
--- a/docs/development/release_notes.md
+++ b/docs/development/release_notes.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## v0.8.1 - Unreleased
+
+- Fixed bug where recipes would fail if the target chunks exceeded the full
+  array length. {issue}`279`
+
 ## v0.8.0 - 2022-02-17
 
 - **Breaking change:** Replace recipe classes' storage attibutes with `.storage_config` of type {class}`pangeo_forge_recipes.storage.StorageConfig`. {pull}`288`

--- a/pangeo_forge_recipes/chunk_grid.py
+++ b/pangeo_forge_recipes/chunk_grid.py
@@ -3,6 +3,7 @@ Abstract representation of ND chunked arrays
 """
 from __future__ import annotations
 
+import warnings
 from itertools import chain, groupby
 from typing import Dict, FrozenSet, Set, Tuple
 
@@ -41,10 +42,17 @@ class ChunkGrid:
         """
         all_chunks = {}
         for name, (chunksize, dimsize) in chunksize_and_dimsize.items():
-            assert dimsize > 0
-            assert (
-                chunksize > 0 and chunksize <= dimsize
-            ), f"invalid chunksize {chunksize} and dimsize {dimsize}"
+            if dimsize <= 0:
+                raise ValueError("dimsize must be greater than 0")
+            if chunksize <= 0:
+                raise ValueError("chunksize must be greater than 0")
+            if chunksize > dimsize:
+                # TODO: make sure this path is more thoroughly tested
+                warnings.warn(
+                    f"chunksize ({chunksize}) > dimsize ({dimsize}). "
+                    f"Decreasing chunksize to {dimsize}"
+                )
+                chunksize = dimsize
             chunks = (dimsize // chunksize) * (chunksize,)
             if dimsize % chunksize > 0:
                 chunks = chunks + (dimsize % chunksize,)

--- a/tests/recipe_tests/test_XarrayZarrRecipe.py
+++ b/tests/recipe_tests/test_XarrayZarrRecipe.py
@@ -168,11 +168,14 @@ def test_recipe_with_references(recipe_fixture, execute_recipe):
 
 
 @pytest.mark.parametrize("recipe_fixture", all_recipes)
-@pytest.mark.parametrize("nkeep", [1, 2])
-def test_prune_recipe(recipe_fixture, execute_recipe, nkeep):
+@pytest.mark.parametrize("nkeep,target_chunks", [(1, None), (2, None), (2, 10)])
+def test_prune_recipe(recipe_fixture, execute_recipe, nkeep, target_chunks):
     """Check that recipe.copy_pruned works as expected."""
 
     RecipeClass, file_pattern, kwargs, ds_expected, target = recipe_fixture
+    if target_chunks:
+        # integration test for https://github.com/pangeo-forge/pangeo-forge-recipes/issues/279
+        kwargs["target_chunks"] = {"time": target_chunks}
     rec = RecipeClass(file_pattern, **kwargs)
     rec_pruned = rec.copy_pruned(nkeep=nkeep)
     assert len(list(rec.iter_inputs())) > len(list(rec_pruned.iter_inputs()))

--- a/tests/test_chunk_grid.py
+++ b/tests/test_chunk_grid.py
@@ -96,6 +96,11 @@ def test_chunk_grid_from_uniform_grid():
     cgb = ChunkGrid({"x": (2,)})  # should be only one chunk
     assert cga == cgb
 
+    with pytest.raises(ValueError):
+        _ = ChunkGrid.from_uniform_grid({"x": (0, 2)})
+    with pytest.raises(ValueError):
+        _ = ChunkGrid.from_uniform_grid({"x": (2, 0)})
+
 
 def test_chunk_grid_consolidate_subset():
     cg = ChunkGrid({"x": (2, 4, 3), "time": (7, 8)})

--- a/tests/test_chunk_grid.py
+++ b/tests/test_chunk_grid.py
@@ -90,6 +90,12 @@ def test_chunk_grid_from_uniform_grid():
     cg2 = ChunkGrid.from_uniform_grid({"x": (2, 4), "y": (3, 10)})
     assert cg1 == cg2
 
+    # test for https://github.com/pangeo-forge/pangeo-forge-recipes/issues/279
+    # create a chunksize greater than dimsize
+    cga = ChunkGrid.from_uniform_grid({"x": (999, 2)})
+    cgb = ChunkGrid({"x": (2,)})  # should be only one chunk
+    assert cga == cgb
+
 
 def test_chunk_grid_consolidate_subset():
     cg = ChunkGrid({"x": (2, 4, 3), "time": (7, 8)})


### PR DESCRIPTION
Hopefully fixes #279

~For now this is only tested at the level of chunk grid. It is possible that bypassing this check will trigger other errors at some point.~

This is tested at both the chunk_grid level and the full Recipe level