### PR TITLE
Add API reference page

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,64 @@
+# API Reference
+
+## File Patterns
+
+
+```{eval-rst}
+.. autoclass:: pangeo_forge_recipes.patterns.FilePattern
+    :members:
+    :special-members: __getitem__, __iter__
+```
+
+### Combine Dimensions
+
+```{eval-rst}
+.. autoclass:: pangeo_forge_recipes.patterns.ConcatDim
+    :members:
+```
+
+
+```{eval-rst}
+.. autoclass:: pangeo_forge_recipes.patterns.MergeDim
+    :members:
+```
+
+### Indexing
+
+```{eval-rst}
+.. autoclass:: pangeo_forge_recipes.patterns.Index
+    :members:
+```
+
+```{eval-rst}
+.. autoclass:: pangeo_forge_recipes.patterns.DimIndex
+    :members:
+```
+
+```{eval-rst}
+.. autoclass:: pangeo_forge_recipes.patterns.CombineOp
+    :members:
+```
+
+
+## Recipes
+
+```{eval-rst}
+.. automodule:: pangeo_forge_recipes.recipes
+   :members:
+```
+
+## Storage
+
+```{eval-rst}
+.. automodule:: pangeo_forge_recipes.storage
+    :members:
+```
+
+
+## Executors
+
+
+```{eval-rst}
+.. automodule:: pangeo_forge_recipes.executors
+   :members:
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,3 +47,5 @@ html_logo = "_static/pangeo-forge-logo-blue.png"
 html_static_path = ["_static"]
 
 myst_heading_anchors = 2
+
+autodoc_mock_imports = ["apache_beam"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,14 +7,14 @@ Resources for understanding and using Pangeo Forge
 New to Pangeo Forge? Start here!
 
 - {doc}`what_is_pangeo_forge` - Read more about Pangeo Forge and how it works!
-- {doc}`intro_tutorial` - Ready to code? Walk through creating and deploying your first Recipe.
+- {doc}`introduction_tutorial/index` - Ready to code? Walk through creating and deploying your first Recipe.
 
 ## How the documentation is organized
 
 There are a number of places to access resources when working with components of Pangeo Forge.
 Here is an overview of what you will find:
 
-- The {doc}`intro_tutorial` is the place to start with Pangeo Forge.
+- The {doc}`introduction_tutorial/index` is the place to start with Pangeo Forge.
   It walks the user through the process of getting set up with their first Recipe.
 - The **User Guides** explain core Pangeo Forge concepts in detail. They provide
   background information to aid in gaining a depth of understanding:
@@ -22,9 +22,9 @@ Here is an overview of what you will find:
   - {doc}`development/index` - For developers seeking to contribute to Pangeo Forge core functionality.
   - {doc}`cloud_automation_user_guide/index` - For digging deeper into the automation systems that
     power Pangeo Forge in the cloud.
-- **Reference Pages** are the complete technical documentation of all Pangeo Forge features.
-  They are useful when you want to review a particular functionality in depth,
-  but assume you already have a working knowledge of the code base
+- {doc}`api_reference` is the complete technical documentation of all Pangeo Forge features.
+  It is useful when you want to review a particular functionality in depth,
+  but assumes you already have a working knowledge of the framework.
 
 ## Repository Reference
 
@@ -51,12 +51,13 @@ If you are new to Pangeo Forge and looking to get involved, we suggest getting s
 ## Site Contents
 
 ```{toctree}
-:maxdepth: 2
+:maxdepth: 3
 
 what_is_pangeo_forge
 introduction_tutorial/index
 recipe_user_guide/index
 cloud_automation_user_guide/index
 tutorials/index
+api_reference
 development/index
 ```

--- a/docs/recipe_user_guide/execution.md
+++ b/docs/recipe_user_guide/execution.md
@@ -8,7 +8,77 @@ Once you have created a recipe object (see {doc}`recipes`) you have two
 options for executing it. In the subsequent code, we will assume that a
 recipe has already been initialized in the variable `recipe`.
 
+
+## Recipes Executors
+
+```{note}
+API reference documentation for execution can be found in {mod}`pangeo_forge_recipes.executors`.
+```
+
+A recipe is an abstract description of a transformation pipeline.
+Recipes can be _compiled_ to executable objects.
+We currently support three types of compilation.
+
+### Python Function
+
+To compile a recipe to a single python function, use the method `.to_function()`.
+For example
+
+```{code-block} python
+recipe_func = recipe.to_function()
+recipe_func()  # actually execute the recipe
+```
+
+Note that the python function approach does not support parallel or distributed execution.
+It's mostly just a convenience utility.
+
+
+### Dask Delayed
+
+You can compile your recipe to a [Dask Delayed](https://docs.dask.org/en/latest/delayed.html)
+object using the `.to_dask()` method. For example
+
+```{code-block} python
+delayed = recipe.to_dask()
+delayed.compute()
+```
+
+The `delayed` object can be executed by any of Dask's schedulers, including
+cloud and HPC distributed schedulers.
+
+### Prefect Flow
+
+You can compile your recipe to a [Prefect Flow](https://docs.prefect.io/core/concepts/flows.html) using
+the :meth:`BaseRecipe.to_prefect()` method. For example
+
+```{code-block} python
+flow = recipe.to_prefect()
+flow.run()
+```
+
+By default the flow is run using Prefect's [LocalExecutor](https://docs.prefect.io/orchestration/flow_config/executors.html#localexecutor). See [executors](https://docs.prefect.io/orchestration/flow_config/executors.html) for more.
+
+### Beam PTransform
+
+You can compile your recipe to an Apache Beam [PTransform](https://beam.apache.org/documentation/programming-guide/#transforms)
+to be used within a [Pipeline](https://beam.apache.org/documentation/programming-guide/#creating-a-pipeline) using the
+:meth:`BaseRecipe.to_beam()` method. For example
+
+```{code-block} python
+import apache_beam as beam
+
+with beam.Pipeline() as p:
+   p | recipe.to_beam()
+```
+
+By default the pipeline runs using Beam's [DirectRunner](https://beam.apache.org/documentation/runners/direct/).
+See [runners](https://beam.apache.org/documentation/#runners) for more.
+
 ## Manual Execution
+
+```{warning}
+We are considering dropping manual execution from the Pangeo Forge API.
+```
 
 A recipe can be executed manually, step by step, in serial, from a notebook
 or interactive interpreter. The ability to manually step through a recipe
@@ -59,64 +129,3 @@ recipe.finalize_target()
 ```
 
 For example, consolidating Zarr metadata happens in the finalize step.
-
-## Compiled Recipes
-
-Very large recipes cannot feasibly be executed this way.
-Instead, recipes can be _compiled_ to executable objects.
-We currently support three types of compilation.
-
-### Python Function
-
-To convert a recipe to a single python function, use the method `.to_function()`.
-For example
-
-```{code-block} python
-recipe_func = recipe.to_function()
-recipe_func()  # actually execute the recipe
-```
-
-Note that the python function approach does not support parallel or distributed execution.
-It's mostly just a convenience utility.
-
-
-### Dask Delayed
-
-You can convert your recipe to a [Dask Delayed](https://docs.dask.org/en/latest/delayed.html)
-object using the `.to_dask()` method. For example
-
-```{code-block} python
-delayed = recipe.to_dask()
-delayed.compute()
-```
-
-The `delayed` object can be executed by any of Dask's schedulers, including
-cloud and HPC distributed schedulers.
-
-### Prefect Flow
-
-You can convert your recipe to a [Prefect Flow](https://docs.prefect.io/core/concepts/flows.html) using
-the :meth:`BaseRecipe.to_prefect()` method. For example
-
-```{code-block} python
-flow = recipe.to_prefect()
-flow.run()
-```
-
-By default the flow is run using Prefect's [LocalExecutor](https://docs.prefect.io/orchestration/flow_config/executors.html#localexecutor). See [executors](https://docs.prefect.io/orchestration/flow_config/executors.html) for more.
-
-### Beam PTransform
-
-You can convert your recipe to an Apache Beam [PTransform](https://beam.apache.org/documentation/programming-guide/#transforms)
-to be used within a [Pipeline](https://beam.apache.org/documentation/programming-guide/#creating-a-pipeline) using the
-:meth:`BaseRecipe.to_beam()` method. For example
-
-```{code-block} python
-import apache_beam as beam
-
-with beam.Pipeline() as p:
-   p | recipe.to_beam()
-```
-
-By default the pipeline runs using Beam's [DirectRunner](https://beam.apache.org/documentation/runners/direct/).
-See [runners](https://beam.apache.org/documentation/#runners) for more.

--- a/docs/recipe_user_guide/file_patterns.md
+++ b/docs/recipe_user_guide/file_patterns.md
@@ -216,39 +216,3 @@ pattern[index]
 
 
 ## File Patterns API
-
-```{eval-rst}
-.. autoclass:: pangeo_forge_recipes.patterns.FilePattern
-    :members:
-    :special-members: __getitem__, __iter__
-```
-
-### Combine Dimensions
-
-```{eval-rst}
-.. autoclass:: pangeo_forge_recipes.patterns.ConcatDim
-    :members:
-```
-
-
-```{eval-rst}
-.. autoclass:: pangeo_forge_recipes.patterns.MergeDim
-    :members:
-```
-
-### Indexing
-
-```{eval-rst}
-.. autoclass:: pangeo_forge_recipes.patterns.Index
-    :members:
-```
-
-```{eval-rst}
-.. autoclass:: pangeo_forge_recipes.patterns.DimIndex
-    :members:
-```
-
-```{eval-rst}
-.. autoclass:: pangeo_forge_recipes.patterns.CombineOp
-    :members:
-```

--- a/docs/recipe_user_guide/index.md
+++ b/docs/recipe_user_guide/index.md
@@ -31,7 +31,7 @@ See {doc}`execution` for details.
 :glob:
 
 file_patterns
-storage
 recipes
+storage
 execution
 ```

--- a/docs/recipe_user_guide/recipes.md
+++ b/docs/recipe_user_guide/recipes.md
@@ -12,7 +12,7 @@ you are reading matches your installed version of pangeo_forge_recipes.
 
 A Recipe is a Python object which encapsulates a workflow for transforming data.
 A Recipe knows how to take a {class}`file pattern <pangeo_forge_recipes.patterns.FilePattern>`,
-which descibes a collection of source files ("inputs"),
+which describes a collection of source files ("inputs"),
 and turn it into a single analysis-ready, cloud-optimized dataset.
 Creating a recipe does not actually cause any data to be read or written; the
 recipe is just the _description_ of the transformation.
@@ -26,9 +26,17 @@ to the public Pangeo Forge {doc}`../cloud_automation_user_guide/recipe_box`, whe
 
 To write a recipe, you must start from one of the existing recipe classes.
 Recipe classes are based on a specific data model for the input files and target dataset format.
-Right now, there is only one recipe class implemented:
+Right now, there are two distinct recipe classes implemented.
+In the future, we may add more.
+
+TODO add rubric for choosing a recipe class.
 
 ### XarrayZarr Recipe
+
+```{note}
+The full API Reference documentation for this recipe class can be found at
+{class}`pangeo_forge_recipes.recipes.XarrayZarrRecipe`
+```
 
 The {class}`pangeo_forge_recipes.recipes.XarrayZarrRecipe` recipe class uses
 [Xarray](http://xarray.pydata.org/) to read the input files and
@@ -85,13 +93,13 @@ move on to {doc}`execution`.
 The API documentation below explains all of the possible options for `XarrayZarrRecipe`.
 Many of these options are explored further in the {doc}`../tutorials/index`.
 
-#### API Documentation
-
-```{eval-rst}
-.. autoclass:: pangeo_forge_recipes.recipes.XarrayZarrRecipe
-```
 
 ### HDF Reference Recipe
+
+```{note}
+The full API Reference documentation for this recipe class can be found at
+{class}`pangeo_forge_recipes.recipes.HDFReferenceRecipe`
+```
 
 Like the `XarrayZarrRecipe`, this recipe allows us to more efficiently access data from a bunch of NetCDF / HDF files.
 However, this recipe does not actually copy the original source data.
@@ -100,11 +108,4 @@ For more background, see [this blog post](https://medium.com/pangeo/fake-it-unti
 
 There is currently one tutorial for this recipe:
 
-- - {doc}`../tutorials/hdf_reference/reference_cmip6`
-
-#### API Documentation
-
-
-```{eval-rst}
-.. autoclass:: pangeo_forge_recipes.recipes.HDFReferenceRecipe
-```
+- {doc}`../tutorials/hdf_reference/reference_cmip6`

--- a/docs/recipe_user_guide/storage.md
+++ b/docs/recipe_user_guide/storage.md
@@ -1,14 +1,25 @@
 # Storage
 
 Recipes need a place to store data. This information is provided to the recipe by its `.storage_config` attribute, which is an object of type {class}`pangeo_forge_recipes.storage.StorageConfig`.
+The `StorageConfig` object looks like this
+
+```{eval-rst}
+.. autoclass:: pangeo_forge_recipes.storage.StorageConfig
+    :noindex:
+```
+
+As shown above, the storage configuration includes three distinct parts: `target`, `cache`, and `metadata`.
 
 ## Default storage
 
-By default, `.storage_config` points to a local [`tempfile.TemporaryDirectory`](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory). This allows you to write data to temporary local storage during the recipe development and debugging process.
+When you create a new recipe, a default `StorageConfig` will automatically be created pointing at a local a local [`tempfile.TemporaryDirectory`](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory).
+This allows you to write data to temporary local storage during the recipe development and debugging process.
+This means that any recipe can immediately be executed with minimal configuration.
+However, in a realistic "production" scenario, you will want to customize your storage locations.
 
 ## Customizing storage: the `target`
 
-To write a recipe's full dataset to a persistant storage location, simply re-assign `.storage_config` to be a {class}`pangeo_forge_recipes.storage.StorageConfig` pointing to the location(s) of your choice. The minimal requirement for instantiating `StorageConfig` is a location in which to store the final dataset produced by the recipe. This is called the ``target``. Pangeo Forge has a special class for this: {class}`pangeo_forge_recipes.storage.FSSpecTarget`.
+To write a recipe's full dataset to a persistant storage location, re-assign `.storage_config` to be a {class}`pangeo_forge_recipes.storage.StorageConfig` pointing to the location(s) of your choice. The minimal requirement for instantiating `StorageConfig` is a location in which to store the final dataset produced by the recipe. This is called the ``target``. Pangeo Forge has a special class for this: {class}`pangeo_forge_recipes.storage.FSSpecTarget`.
 
 Creating a ``target`` requires two arguments:
 - The ``fs`` argument is an [fsspec](https://filesystem-spec.readthedocs.io/en/latest/)
@@ -58,28 +69,4 @@ cache = CacheFSSpecTarget(fs=<fsspec-filesystem-for-cache>, root_path="<path-for
 metadata = MetadataTarget(fs=<fsspec-filesystem-for-metadata>, root_path="<path-for-metadata>")
 
 recipe.storage_config = StorageConfig(target, cache, metadata)
-```
-
-## API
-
-```{eval-rst}
-.. autoclass:: pangeo_forge_recipes.storage.StorageConfig
-    :members:
-```
-
-```{eval-rst}
-.. autoclass:: pangeo_forge_recipes.storage.FSSpecTarget
-    :members:
-```
-
-```{eval-rst}
-.. autoclass:: pangeo_forge_recipes.storage.CacheFSSpecTarget
-    :members:
-    :show-inheritance:
-```
-
-```{eval-rst}
-.. autoclass:: pangeo_forge_recipes.storage.MetadataTarget
-    :members:
-    :show-inheritance:
 ```

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -16,9 +16,9 @@ xarray_zarr/terraclimate
 xarray_zarr/opendap_subset_recipe
 ```
 
-## ReferenceHDFRecipe
+## HDFReferenceRecipe
 
-These tutorials all use the {class}`pangeo_forge_recipes.recipes.ReferenceHDFRecipe` class:
+These tutorials all use the {class}`pangeo_forge_recipes.recipes.HDFReferenceRecipe` class:
 
 ```{toctree}
 :maxdepth: 1

--- a/pangeo_forge_recipes/recipes/__init__.py
+++ b/pangeo_forge_recipes/recipes/__init__.py
@@ -1,7 +1,8 @@
+from .base import BaseRecipe
 from .reference_hdf_zarr import HDFReferenceRecipe
 from .xarray_zarr import XarrayZarrRecipe
 
-__all__ = ["XarrayZarrRecipe", "HDFReferenceRecipe"]
+__all__ = ["BaseRecipe", "XarrayZarrRecipe", "HDFReferenceRecipe"]
 
 
 def setup_logging(level: str = "INFO"):


### PR DESCRIPTION
This PR refactors the documentation to have all the API docs on a new standalone top-level page, rather than sprinkling them through the docs themselves. This better matches the "How the documentation is organized" concept from the main index.