### PR TITLE
Homepage links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,48 +4,38 @@ Resources for understanding and using Pangeo Forge
 
 ## First Steps
 
-New to Pangeo Forge? Start here!
+New to Pangeo Forge? You are in the right spot!
 
 - {doc}`what_is_pangeo_forge` - Read more about Pangeo Forge and how it works!
-- {doc}`intro_tutorial` - Ready to code? Walk through creating and deploying your first Recipe.
+- {doc}`introduction_tutorial/index` - Ready to code? Walk through creating, running, and staging your first Recipe.
 
 ## How the documentation is organized
 
-There are a number of places to access resources when working with components of Pangeo Forge.
-Here is an overview of what you will find:
+There are a number of resources available when working with Pangeo Forge:
 
-- The {doc}`intro_tutorial` is the place to start with Pangeo Forge.
-  It walks the user through the process of getting set up with their first Recipe.
-- The **User Guides** explain core Pangeo Forge concepts in detail. They provide
+- **User Guides** explain core Pangeo Forge concepts in detail. They provide
   background information to aid in gaining a depth of understanding:
   - {doc}`recipe_user_guide/index` - For learning about how to create Recipes.
-  - {doc}`development/index` - For developers seeking to contribute to Pangeo Forge core functionality.
   - {doc}`cloud_automation_user_guide/index` - For digging deeper into the automation systems that
-    power Pangeo Forge in the cloud.
-- **Reference Pages** are the complete technical documentation of all Pangeo Forge features.
+    power Pangeo Forge Cloud.
+  - {doc}`development/index` - For developers seeking to contribute to Pangeo Forge core functionality.
+- **{doc}`tutorials/index`** walk through examples of using Pangeo Forge Recipes. They are a good second step after the Introduction Tutorial.
+- The **API Reference** is the complete technical documentation of all Pangeo Forge features.
   They are useful when you want to review a particular functionality in depth,
   but assume you already have a working knowledge of the code base
 
-## Repository Reference
+## Connecting with the Community
 
-There are many respositories that make up Pangeo Forge. Here are links to the different documentation pages:
+Pangeo Forge is a community run effort with a variety of roles:
 
-- pangeo-forge-recipes
-- pangeo-forge-azure-bakery
-- pangeo-forge-aws-bakery
+- **Recipe contributors** — contributors who write recipes to define the data conversions. This can be anyone with a desire to create analysis ready cloud-optimized (ARCO) data.
+- **Bakery operators** — individuals or instituations who deploy bakeries on cloud infrastructure to process and host the transformed data. This is typically an organization with a grant to fund the infrastructure.
+- **Pangeo forge developers** - scientists and software developers who maintain and enhance the open-source code base which makes Pangeo Forge run. See {doc}`development/index`.
 
-## Connecting the Community
+If you are new to Pangeo Forge and looking to get involved, we suggest starting with recipe contribution. You can do in two ways:
 
-Pangeo Forge is a community run effort. There are different roles that people play to support the effort:
-
-- Recipe contributors — contributors who write recipes to define the data conversions. This can be anyone with a desire to create analysis ready cloud-optimized (ARCO) data
-- Bakery operators — individuals or instituations who deploy bakeries on cloud infrastructure to process and host the transformed data. This is typically an organization with a grant to fund the infrastructure
-- Pangeo forge developers - scientists and software developers who contribute to maintaining and enhancing the open-source code base which makes Pangeo Forge run.
-
-If you are new to Pangeo Forge and looking to get involved, we suggest getting started with recipe contribution. You can do in two ways:
-
-- Open a ticket with a dataset request (no code required!) - Get started here (link)
-- Write a recipe for a dataset you'd like to see transformed - See recipe creation docs
+- Open a ticket with a dataset request (no code required!) - Explore other [recipe proposals](https://github.com/pangeo-forge/pangeo-forge-recipes/issues) and [create your own ticket](https://github.com/pangeo-forge/staged-recipes/issues/new/choose)
+- Write a recipe for a dataset you'd like to see transformed - Get started with the {doc}`introduction_tutorial/index`
 
 
 ## Site Contents


### PR DESCRIPTION
### Context
task in #302 
> Many missing links under [Connecting the Community](https://pangeo-forge.readthedocs.io/en/latest/#connecting-the-community)

### Tasks
- fix broken links
- update text

### Status
Left as a draft until #303 is merged so the link to the API Reference can be added.