### PR TITLE
Add links to sandbox in installation and tutorials

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,10 +13,23 @@ If you have not added the conda forge channel or set it as your default channel 
 
 If those steps are complete you can install the library with `conda install pangeo-forge-recipes`.
 
-## Remote access
+## Pangeo Forge Sandbox
 
-Pangeo Forge also has a [code sandbox](https://github.com/pangeo-forge/sandbox) which has `pangeo-forge-recipes` installed and template documents for creatig a recipe. Click the button below to launch the sandbox using Binder:
+Pangeo Forge also has a [code sandbox](https://github.com/pangeo-forge/sandbox) accessible online. The sandbox is an environment with `pangeo-forge-recipes` installed and template documents for creating a recipe. There are two versions of this environment:
+1. A Template Workspace
+The template workspace contains template files for creating and submitting a recipe.
+Click the button below to launch the template workspace using Binder:
 
+Note: incorrect link
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pangeo-forge/sandbox/binder)
 
-You'll also notice that the tutorials have Binder links. The binder links can be used to explore `pangeo-forge-recipes` without setting up a local environment.
+2. A Blank Environment
+The blank environment is a JupyterLab environment with a blank notebook.
+Click the button below to launch the blank environment using Binder:
+
+Note: incorrect link
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pangeo-forge/sandbox/binder)
+
+Either can be used to start building recipes!
+
+You'll also notice that the {doc}`tutorials/index` have Binder links. The binder links can be used to explore the recipe tutorials without setting up a local environment.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,21 +15,6 @@ If those steps are complete you can install the library with `conda install pang
 
 ## Pangeo Forge Sandbox
 
-Pangeo Forge also has a [code sandbox](https://github.com/pangeo-forge/sandbox) accessible online. The sandbox is an environment with `pangeo-forge-recipes` installed and template documents for creating a recipe. There are two versions of this environment:
-1. A Template Workspace
-The template workspace contains template files for creating and submitting a recipe.
-Click the button below to launch the template workspace using Binder:
-
-Note: incorrect link
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pangeo-forge/sandbox/binder)
-
-2. A Blank Environment
-The blank environment is a JupyterLab environment with a blank notebook.
-Click the button below to launch the blank environment using Binder:
-
-Note: incorrect link
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pangeo-forge/sandbox/binder)
-
-Either can be used to start building recipes!
+Pangeo Forge also has a [code sandbox](https://github.com/pangeo-forge/sandbox) accessible online! The sandbox is an environment with `pangeo-forge-recipes` installed and template documents for creating a recipe. Links to both a Template work environment and a blank work environment with `pangeo-forge-recipes` installed are available in the [sandbox README](https://github.com/pangeo-forge/sandbox/blob/main/README.md).
 
 You'll also notice that the {doc}`tutorials/index` have Binder links. The binder links can be used to explore the recipe tutorials without setting up a local environment.

--- a/docs/introduction_tutorial/intro_tutorial_part1.ipynb
+++ b/docs/introduction_tutorial/intro_tutorial_part1.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "Throughout this tutorial we are going to convert NOAA OISST stored in netCDF to Zarr. OISST is a global, gridded ocean sea surface temperature dataset at daily 1/4 degree resolution. By the end of this tutorial sequence you will have converted some OISST data to zarr, be able to access a sample on your computer, and see how to propose the recipe for cloud deployment!\n",
     "\n",
-    "Here we tackle **Part 1 - Defining a `FilePattern`**. We will assume that you already have `pangeo-forge-recipes` installed."
+    "Here we tackle **Part 1 - Defining a `FilePattern`**. We will assume that you already have `pangeo-forge-recipes` installed (See {doc}`/installation`). Alternately, you could run this tutorial in the Pangeo Forge Sandbox. (Add link TODO) "
    ]
   },
   {


### PR DESCRIPTION
## What was done
- updated the text on the Installation page to emphasize the sandbox
- Added a link to the installation page and to the sandbox at the top of each tutorial (incomplete)

## Notes

~@cisaacstern would you be able to tell me how to get the sandbox link from the button in [the sandbox repo](https://github.com/pangeo-forge/sandbox)? The existing binder link is incorrect.~ ~Update: I figure you're not awake yet but still scratch that. I'm rearranging some things.~ Update on the update: New commit, but I'm still not sure about generating a link. Perhaps we can talk about it at our meeting later.