### PR TITLE
CI env: drop pynio, move kerchunk to conda deps

### DIFF
--- a/ci/py3.8.yml
+++ b/ci/py3.8.yml
@@ -20,6 +20,7 @@ dependencies:
   - intake
   - intake-xarray
   - lxml
+  - kerchunk>=0.0.4
   - netcdf4
   - numcodecs
   - numpy
@@ -27,7 +28,10 @@ dependencies:
   - pip
   - prefect
   - pydap
-  - pynio
+  # bring back eventually once pynio conda-forge package does not conflict
+  # with ujson, which is a depencency of kerchunk's conda-forge feedstock.
+  # See: https://github.com/conda-forge/pynio-feedstock/issues/114
+  # - pynio
   - pytest
   - pytest-cov
   - pytest-lazy-fixture
@@ -45,4 +49,3 @@ dependencies:
   - pip:
     - h5py>=3.3.0
     - pytest-timeout
-    - kerchunk>=0.0.4

--- a/ci/py3.9.yml
+++ b/ci/py3.9.yml
@@ -28,8 +28,10 @@ dependencies:
   - pip
   - prefect
   - pydap
-# bring back eventually once pynio conda-forge package supports py3.9
-#  - pynio
+  # bring back eventually once pynio conda-forge package supports py3.9 and does not
+  # conflict with ujson, which is a depencency of kerchunk's conda-forge feedstock.
+  # See: https://github.com/conda-forge/pynio-feedstock/issues/114
+  #  - pynio
   - pytest
   - pytest-cov
   - pytest-lazy-fixture


### PR DESCRIPTION
Closes #325

We can add `pynio` back into `3.8` env once https://github.com/conda-forge/pynio-feedstock/issues/114 is resolved, and back into `3.9` env once that issue plus https://github.com/conda-forge/pynio-feedstock/issues/100 is resolved.