### PR TITLE
Revive pynio in ci envs

### DIFF
--- a/ci/py3.8.yml
+++ b/ci/py3.8.yml
@@ -28,10 +28,7 @@ dependencies:
   - pip
   - prefect
   - pydap
-  # bring back eventually once pynio conda-forge package does not conflict
-  # with ujson, which is a depencency of kerchunk's conda-forge feedstock.
-  # See: https://github.com/conda-forge/pynio-feedstock/issues/114
-  # - pynio
+  - pynio
   - pytest
   - pytest-cov
   - pytest-lazy-fixture

--- a/ci/py3.9.yml
+++ b/ci/py3.9.yml
@@ -29,10 +29,7 @@ dependencies:
   - pip
   - prefect
   - pydap
-  # bring back eventually once pynio conda-forge package supports py3.9 and does not
-  # conflict with ujson, which is a depencency of kerchunk's conda-forge feedstock.
-  # See: https://github.com/conda-forge/pynio-feedstock/issues/114
-  #  - pynio
+  - pynio
   - pytest
   - pytest-cov
   - pytest-lazy-fixture


### PR DESCRIPTION
Following refresh of pynio feedstock (xref https://github.com/conda-forge/pynio-feedstock/issues/114#issuecomment-1082368476), I believe we can add this dependency back into the CI envs. Let's see if all the tests pass.