### PR TITLE
Add date to 0.8.3 release note

### DIFF
--- a/docs/pangeo_forge_recipes/development/release_notes.md
+++ b/docs/pangeo_forge_recipes/development/release_notes.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## v0.8.3 -
+## v0.8.3 - 2022-04-19
 
 - Added `.file_type` attribute to {class}`pangeo_forge_recipes.patterns.FilePattern`. This attribute will eventually supercede
 `.is_opendap`, which will be deprecated in `0.9.0`. Until then, `FilePattern(..., is_opendap=True)` is supported as equivalent


### PR DESCRIPTION
In order to push https://github.com/pangeo-forge/noaa-coastwatch-geopolar-sst-feedstock/issues/2#issuecomment-1102950710 forward, we need a `0.8.3`, the main substantive difference with `0.8.2` being the addition of `FileType`, which is described in the release notes.