### PR TITLE
Fix tutorials workflow base path

### DIFF
--- a/.github/workflows/tutorials.yaml
+++ b/.github/workflows/tutorials.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: 🏗 Build Notebook
         shell: bash -l {0}
         run: >
-          pytest --timeout=3000 --nbmake docs/tutorials/${{ matrix.nb-path }}
+          pytest --timeout=3000 --nbmake docs/pangeo_forge_recipes/tutorials/${{ matrix.nb-path }}
 
       # finish the check
       # this won't work if we are not inside a repository_dispatch event,


### PR DESCRIPTION
After merging #339, all of the tutorials workflows failed, because the docs directory structure changed. This fixes that.