### PR TITLE
Add Beam to py3.9 ci

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -102,9 +102,6 @@ jobs:
                       "executor_dask", "executor_prefect", "executor_prefect_dask",
                       "executor_prefect_wrapper", "executor_beam"]
         exclude:
-          # No beam support in python 3.9
-          - python-version: 3.9
-            pytest-mark: "executor_beam"
           - dependencies: "upstream-dev"
             pytest-mark: "executor_function"
           - dependencies: "upstream-dev"

--- a/ci/py3.9.yml
+++ b/ci/py3.9.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3.9
   - aiohttp
+  - apache-beam
   - black
   - boto3
   - cfgrib<0.9.9.0


### PR DESCRIPTION
Thanks to https://github.com/conda-forge/apache-beam-feedstock/pull/49, we can now install Beam via conda in python 3.9.