### PR TITLE
try opening with contextmanager

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,7 +6,7 @@ on:
     paths-ignore:
     - 'docs/**'
   pull_request:
-    branches: master
+    branches: [master, beam-refactor]
     paths-ignore:
     - 'docs/**'
 

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -51,7 +51,14 @@ class OpenWithXarray(beam.PTransform):
 
     def _open_with_xarray(self, element: Tuple[Index, Any]) -> Tuple[Index, xr.Dataset]:
         key, open_file = element
-        ds = xr.open_dataset(open_file, **self.xarray_open_kwargs)
+        print(f"open_file is {open_file}")
+        try:
+            ds = xr.open_dataset(open_file, **self.xarray_open_kwargs)
+        except ValueError:
+            with open_file as fp:
+                print("failed, now trying with context manager")
+                print(f"fp is {fp}")
+                ds = xr.open_dataset(fp, **self.xarray_open_kwargs)
         return key, ds
 
     def expand(self, pcoll):

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -51,13 +51,10 @@ class OpenWithXarray(beam.PTransform):
 
     def _open_with_xarray(self, element: Tuple[Index, Any]) -> Tuple[Index, xr.Dataset]:
         key, open_file = element
-        print(f"open_file is {open_file}")
         try:
             ds = xr.open_dataset(open_file, **self.xarray_open_kwargs)
         except ValueError:
             with open_file as fp:
-                print("failed, now trying with context manager")
-                print(f"fp is {fp}")
                 ds = xr.open_dataset(fp, **self.xarray_open_kwargs)
         return key, ds
 

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -51,12 +51,9 @@ class OpenWithXarray(beam.PTransform):
 
     def _open_with_xarray(self, element: Tuple[Index, Any]) -> Tuple[Index, xr.Dataset]:
         key, open_file = element
-        try:
-            ds = xr.open_dataset(open_file, **self.xarray_open_kwargs)
-        except ValueError:
-            with open_file as fp:
-                ds = xr.open_dataset(fp, **self.xarray_open_kwargs)
-        return key, ds
+        with open_file as fp:
+            with xr.open_dataset(fp, **self.xarray_open_kwargs) as ds:
+                return key, ds
 
     def expand(self, pcoll):
         return pcoll | "Open with Xarray" >> beam.Map(self._open_with_xarray)


### PR DESCRIPTION
This is one possible workaround for https://github.com/fsspec/filesystem_spec/issues/579

This fails with the following error

```
apache_beam/coders/coder_impl.py:268: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

x = <xarray.Dataset>
Dimensions:  (time: 1, lat: 18, lon: 36)
Coordinates:
  * time     (time) datetime64[ns] 2010-01-01
 ...
    bar      (time, lat, lon) int64 ...
    foo      (time, lat, lon) float64 ...
Attributes:
    conventions:  CF 1.6

>   lambda x: dumps(x, protocol), pickle.loads)

../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/coders/coders.py:802: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <File-like object HTTPFileSystem, http://127.0.0.1:53014/000.nc>

    def __reduce__(self):
        return (
            reopen,
            (
                self.fs,
                self.url,
                self.mode,
                self.blocksize,
>               self.cache.name,
                self.size,
            ),
        )
E       AttributeError: 'NoneType' object has no attribute 'name'

../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/fsspec/implementations/http.py:637: AttributeError

During handling of the above exception, another exception occurred:

pcoll_xarray_datasets = <_ChainedPTransform(PTransform) label=[Create|OpenWithFSSpec|OpenWithXarray] at 0x7ff11a6e23d0>

    def test_OpenWithXarray(pcoll_xarray_datasets):
        with TestPipeline() as p:
            output = p | pcoll_xarray_datasets
    
>           assert_that(output, is_xr_dataset(), label="is xr.Dataset")

tests/test_beam.py:93: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/pipeline.py:596: in __exit__
    self.result = self.run()
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/testing/test_pipeline.py:112: in run
    result = super().run(
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/pipeline.py:546: in run
    return Pipeline.from_runner_api(
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/pipeline.py:573: in run
    return self.runner.run_pipeline(self, self._options)
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/runners/direct/direct_runner.py:131: in run_pipeline
    return runner.run_pipeline(pipeline, options)
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/runners/portability/fn_api_runner/fn_runner.py:199: in run_pipeline
    self._latest_run_result = self.run_via_runner_api(
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/runners/portability/fn_api_runner/fn_runner.py:210: in run_via_runner_api
    return self.run_stages(stage_context, stages)
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/runners/portability/fn_api_runner/fn_runner.py:392: in run_stages
    stage_results = self._run_stage(
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/runners/portability/fn_api_runner/fn_runner.py:657: in _run_stage
    self._run_bundle(
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/runners/portability/fn_api_runner/fn_runner.py:780: in _run_bundle
    result, splits = bundle_manager.process_bundle(
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/runners/portability/fn_api_runner/fn_runner.py:1091: in process_bundle
    result_future = self._worker_handler.control_conn.push(process_bundle_req)
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/runners/portability/fn_api_runner/worker_handlers.py:378: in push
    response = self.worker.do_instruction(request)
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/runners/worker/sdk_worker.py:580: in do_instruction
    return getattr(self, request_type)(
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/runners/worker/sdk_worker.py:618: in process_bundle
    bundle_processor.process_bundle(instruction_id))
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/runners/worker/bundle_processor.py:995: in process_bundle
    input_op_by_transform_id[element.transform_id].process_encoded(
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/runners/worker/bundle_processor.py:221: in process_encoded
    self.output(decoded_value)
apache_beam/runners/worker/operations.py:346: in apache_beam.runners.worker.operations.Operation.output
    ???
apache_beam/runners/worker/operations.py:348: in apache_beam.runners.worker.operations.Operation.output
    ???
apache_beam/runners/worker/operations.py:215: in apache_beam.runners.worker.operations.SingletonConsumerSet.receive
    ???
apache_beam/runners/worker/operations.py:707: in apache_beam.runners.worker.operations.DoOperation.process
    ???
apache_beam/runners/worker/operations.py:708: in apache_beam.runners.worker.operations.DoOperation.process
    ???
apache_beam/runners/common.py:1200: in apache_beam.runners.common.DoFnRunner.process
    ???
apache_beam/runners/common.py:1265: in apache_beam.runners.common.DoFnRunner._reraise_augmented
    ???
apache_beam/runners/common.py:1198: in apache_beam.runners.common.DoFnRunner.process
    ???
apache_beam/runners/common.py:536: in apache_beam.runners.common.SimpleInvoker.invoke_process
    ???
apache_beam/runners/common.py:1361: in apache_beam.runners.common._OutputProcessor.process_outputs
    ???
apache_beam/runners/worker/operations.py:215: in apache_beam.runners.worker.operations.SingletonConsumerSet.receive
    ???
apache_beam/runners/worker/operations.py:707: in apache_beam.runners.worker.operations.DoOperation.process
    ???
apache_beam/runners/worker/operations.py:708: in apache_beam.runners.worker.operations.DoOperation.process
    ???
apache_beam/runners/common.py:1200: in apache_beam.runners.common.DoFnRunner.process
    ???
apache_beam/runners/common.py:1265: in apache_beam.runners.common.DoFnRunner._reraise_augmented
    ???
apache_beam/runners/common.py:1198: in apache_beam.runners.common.DoFnRunner.process
    ???
apache_beam/runners/common.py:536: in apache_beam.runners.common.SimpleInvoker.invoke_process
    ???
apache_beam/runners/common.py:1361: in apache_beam.runners.common._OutputProcessor.process_outputs
    ???
apache_beam/runners/worker/operations.py:215: in apache_beam.runners.worker.operations.SingletonConsumerSet.receive
    ???
apache_beam/runners/worker/operations.py:707: in apache_beam.runners.worker.operations.DoOperation.process
    ???
apache_beam/runners/worker/operations.py:708: in apache_beam.runners.worker.operations.DoOperation.process
    ???
apache_beam/runners/common.py:1200: in apache_beam.runners.common.DoFnRunner.process
    ???
apache_beam/runners/common.py:1265: in apache_beam.runners.common.DoFnRunner._reraise_augmented
    ???
apache_beam/runners/common.py:1198: in apache_beam.runners.common.DoFnRunner.process
    ???
apache_beam/runners/common.py:536: in apache_beam.runners.common.SimpleInvoker.invoke_process
    ???
apache_beam/runners/common.py:1361: in apache_beam.runners.common._OutputProcessor.process_outputs
    ???
apache_beam/runners/worker/operations.py:215: in apache_beam.runners.worker.operations.SingletonConsumerSet.receive
    ???
apache_beam/runners/worker/operations.py:707: in apache_beam.runners.worker.operations.DoOperation.process
    ???
apache_beam/runners/worker/operations.py:708: in apache_beam.runners.worker.operations.DoOperation.process
    ???
apache_beam/runners/common.py:1200: in apache_beam.runners.common.DoFnRunner.process
    ???
apache_beam/runners/common.py:1265: in apache_beam.runners.common.DoFnRunner._reraise_augmented
    ???
apache_beam/runners/common.py:1198: in apache_beam.runners.common.DoFnRunner.process
    ???
apache_beam/runners/common.py:536: in apache_beam.runners.common.SimpleInvoker.invoke_process
    ???
apache_beam/runners/common.py:1361: in apache_beam.runners.common._OutputProcessor.process_outputs
    ???
apache_beam/runners/worker/operations.py:215: in apache_beam.runners.worker.operations.SingletonConsumerSet.receive
    ???
apache_beam/runners/worker/operations.py:707: in apache_beam.runners.worker.operations.DoOperation.process
    ???
apache_beam/runners/worker/operations.py:708: in apache_beam.runners.worker.operations.DoOperation.process
    ???
apache_beam/runners/common.py:1200: in apache_beam.runners.common.DoFnRunner.process
    ???
apache_beam/runners/common.py:1281: in apache_beam.runners.common.DoFnRunner._reraise_augmented
    ???
apache_beam/runners/common.py:1198: in apache_beam.runners.common.DoFnRunner.process
    ???
apache_beam/runners/common.py:536: in apache_beam.runners.common.SimpleInvoker.invoke_process
    ???
apache_beam/runners/common.py:1361: in apache_beam.runners.common._OutputProcessor.process_outputs
    ???
apache_beam/runners/worker/operations.py:214: in apache_beam.runners.worker.operations.SingletonConsumerSet.receive
    ???
apache_beam/runners/worker/operations.py:178: in apache_beam.runners.worker.operations.ConsumerSet.update_counters_start
    ???
apache_beam/runners/worker/opcounters.py:211: in apache_beam.runners.worker.opcounters.OperationCounters.update_from
    ???
apache_beam/runners/worker/opcounters.py:250: in apache_beam.runners.worker.opcounters.OperationCounters.do_sample
    ???
apache_beam/coders/coder_impl.py:1425: in apache_beam.coders.coder_impl.WindowedValueCoderImpl.get_estimated_size_and_observables
    ???
apache_beam/coders/coder_impl.py:1436: in apache_beam.coders.coder_impl.WindowedValueCoderImpl.get_estimated_size_and_observables
    ???
apache_beam/coders/coder_impl.py:377: in apache_beam.coders.coder_impl.FastPrimitivesCoderImpl.get_estimated_size_and_observables
    ???
apache_beam/coders/coder_impl.py:416: in apache_beam.coders.coder_impl.FastPrimitivesCoderImpl.encode_to_stream
    ???
apache_beam/coders/coder_impl.py:441: in apache_beam.coders.coder_impl.FastPrimitivesCoderImpl.encode_to_stream
    ???
apache_beam/coders/coder_impl.py:268: in apache_beam.coders.coder_impl.CallbackCoderImpl.encode_to_stream
    ???
../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/apache_beam/coders/coders.py:802: in <lambda>
    lambda x: dumps(x, protocol), pickle.loads)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <File-like object HTTPFileSystem, http://127.0.0.1:53014/000.nc>

    def __reduce__(self):
        return (
            reopen,
            (
                self.fs,
                self.url,
                self.mode,
                self.blocksize,
>               self.cache.name,
                self.size,
            ),
        )
E       AttributeError: 'NoneType' object has no attribute 'name' [while running 'Create|OpenWithFSSpec|OpenWithXarray/OpenWithXarray/Open with Xarray']

../../anaconda/envs/pangeo-forge-recipes/lib/python3.8/site-packages/fsspec/implementations/http.py:637: AttributeError

```