### PR TITLE
Small fix in prepare_target: catch `PathNotFoundError`.

### DIFF
--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -507,7 +507,7 @@ def prepare_target(*, config: XarrayZarrRecipe) -> None:
             # TODO: check that target_chunks id compatibile with the
             # existing chunks
             pass
-    except (FileNotFoundError, IOError, zarr.errors.GroupNotFoundError):
+    except (FileNotFoundError, IOError, zarr.errors.GroupNotFoundError, zarr.errors.PathNotFoundError):
         logger.info("Creating a new dataset in target")
 
         # need to rewrite this as an append loop

--- a/pangeo_forge_recipes/recipes/xarray_zarr.py
+++ b/pangeo_forge_recipes/recipes/xarray_zarr.py
@@ -507,7 +507,12 @@ def prepare_target(*, config: XarrayZarrRecipe) -> None:
             # TODO: check that target_chunks id compatibile with the
             # existing chunks
             pass
-    except (FileNotFoundError, IOError, zarr.errors.GroupNotFoundError, zarr.errors.PathNotFoundError):
+    except (
+        FileNotFoundError,
+        IOError,
+        zarr.errors.GroupNotFoundError,
+        zarr.errors.PathNotFoundError,
+    ):
         logger.info("Creating a new dataset in target")
 
         # need to rewrite this as an append loop


### PR DESCRIPTION
Prepare target checks if a Zarr exists by attempting to open a Zarr and then creating one when an error occurs. I've found that in addition to the `zarr.errors.GroupNotFoundError`, the `zarr.errors.PathNotFoundError` needs to be caught in order to not break the xarray_zarr.py pipeline.