### PR TITLE
Add project coordination page

### DIFF
--- a/docs/pangeo_forge_recipes/development/coordination.md
+++ b/docs/pangeo_forge_recipes/development/coordination.md
@@ -1,0 +1,19 @@
+# Project Coordination
+
+## Developer Meetings
+
+We hold bi-weekly developer meetings **Every other Monday at 2pm ET**.
+
+- Conferencing: <https://whereby.com/pangeo>
+- Meeting Notes: <https://docs.google.com/document/d/14FpI9vaM6TeFtmM7LP9o_d5DZaYKgQVTTzT7tFRt-Nw>
+
+
+The meeting details are also visible on the general
+[Pangeo Meeting calendar](https://pangeo.io/meeting-notes.html)
+
+<iframe src="https://calendar.google.com/calendar/b/1/embed?title=Upcoming%20Pangeo%20Meetings&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;mode=AGENDA&amp;height=300&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=ucar.edu_c23ln4014khs3f65o93vqv5kqc%40group.calendar.google.com&amp;color=%23711616&amp;ctz=America%2FLos_Angeles" style="border-width:0" width="100%" height="300" frameborder="0" scrolling="no"></iframe>
+
+## User Stories and Milestones
+
+To help focus development, we track user stories and milestones in a standalone repo:
+<https://github.com/pangeo-forge/user-stories/issues>

--- a/docs/pangeo_forge_recipes/development/coordination.md
+++ b/docs/pangeo_forge_recipes/development/coordination.md
@@ -2,6 +2,10 @@
 
 ## Developer Meetings
 
+Anyone is welcome to join the Pangeo Forge development community!
+(As long as you follow the [Pangeo code of conduct](https://github.com/pangeo-data/governance/blob/master/conduct/code_of_conduct.md).)
+
+
 We hold bi-weekly developer meetings **Every other Monday at 2pm ET**.
 
 - Conferencing: <https://whereby.com/pangeo>

--- a/docs/pangeo_forge_recipes/development/index.md
+++ b/docs/pangeo_forge_recipes/development/index.md
@@ -5,6 +5,7 @@ These pages contain documentation for Pangeo Forge developers and contibutors.
 ```{toctree}
 :maxdepth: 1
 
+coordination
 development_guide
 release_notes
 ```


### PR DESCRIPTION
I thought it would be useful to have this information in our documentation, rather than buried in the issue tracker.