### PR TITLE
Remove most pins from doc requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,10 @@
-sphinx==3.5.4
-pangeo-sphinx-book-theme==0.1.2
-myst-parser==0.13.6
-myst-nb==0.12.3
-sphinx-copybutton==0.3.1
-sphinx-togglebutton==0.2.2
-sphinx-autodoc-typehints==1.12.0
-sphinx-panels==0.6.0
-sphinxext-opengraph>=0.6.3
-# https://github.com/sphinx-doc/sphinx/issues/10291#issuecomment-1078046986
-jinja2<3.1
+sphinx<5
+pangeo-sphinx-book-theme>=0.2
+myst-parser
+myst-nb
+sphinx-copybutton
+sphinx-togglebutton
+sphinx-autodoc-typehints
+sphinx-panels
+sphinxext-opengraph
 -e .


### PR DESCRIPTION
Thanks to https://github.com/pangeo-forge/pangeo-sphinx-book-theme/pull/9, we should be able to use all the latest versions of stuff. Let's see how the RTD build goes.