### PR TITLE
Exclude `fsspec.open_kwargs["client_kwargs"]` from pattern hash computation

### DIFF
--- a/pangeo_forge_recipes/patterns.py
+++ b/pangeo_forge_recipes/patterns.py
@@ -297,7 +297,15 @@ def pattern_blockchain(pattern: FilePattern) -> List[bytes]:
     # index:filepath pairs yielded by iterating over ``.items()``. if these pairs are generated in
     # a different way in the future, we ultimately don't care.
     root = {
-        "fsspec_open_kwargs": pattern.fsspec_open_kwargs,
+        "fsspec_open_kwargs": {
+            k: v
+            for k, v in pattern.fsspec_open_kwargs.items()
+            # `client_kwargs` is excluded because it can contain 
+            # hard-to-hash objects, e.g. aiohttp.ClientTimeout.
+            # This avoids subsequent errors in 
+            # `serialization.either_encode_or_hash()`.
+            if k != "client_kwargs"
+        },
         "query_string_secrets": pattern.query_string_secrets,
         "file_type": pattern.file_type,
         "nitems_per_file": {

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,4 +1,5 @@
-from dataclasses import asdict, dataclass, field
+import aiohttp
+from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -99,6 +100,30 @@ def test_recipe_sha256_hash_exclude(base_pattern, recipe_cls, tmpdir_factory):
     custom_storage_config = StorageConfig(target=FSSpecTarget(local_fs, custom_target_path))
     recipe_1.storage_config = custom_storage_config
 
+    assert recipe_0.sha256 == recipe_1.sha256
+
+
+@pytest.mark.parametrize("recipe_cls", [XarrayZarrRecipe, HDFReferenceRecipe])
+def test_recipe_sha256_hash_exclude_fsspec_open_kwargs(base_pattern, recipe_cls, tmpdir_factory):
+    recipe_0 = recipe_cls(base_pattern)
+    recipe_1 = recipe_cls(base_pattern)
+
+    assert recipe_0.sha256 == recipe_1.sha256
+
+    # Specify fsspec_open_kwargs that will be excluded,
+    # e.g. client_kwargs containing certain aiohttp objects
+    # that can't be easily hashed. This avoids subsequent errors in
+    # `serialization.either_encode_or_hash()`.
+    def aio_file_pattern(client_kwargs):
+        return FilePattern(base_pattern.format_function,
+                           base_pattern.combine_dims[0],
+                           fsspec_open_kwargs={"client_kwargs": client_kwargs})
+
+    # Recipe hash computation, including file pattern computation, occurs with replace()
+    replace(recipe_1, file_pattern=aio_file_pattern({"auth": aiohttp.BasicAuth(login="test", password="test")}))
+    assert recipe_0.sha256 == recipe_1.sha256
+
+    replace(recipe_1, file_pattern=aio_file_pattern({"timeout": aiohttp.ClientTimeout(total=1800)}))
     assert recipe_0.sha256 == recipe_1.sha256
 
 


### PR DESCRIPTION
Fixes #443 using the proposed solution. Corresponding test cases added.