### PR TITLE
Move FilePattern functions into methods

### DIFF
--- a/docs/pangeo_forge_recipes/development/release_notes.md
+++ b/docs/pangeo_forge_recipes/development/release_notes.md
@@ -10,7 +10,7 @@ Collectively, this provides for generation of deterministic hashes for both reci
 pattern instances. Checking these hashes against those from a prior version of the recipe can be
 used to determine whether or not a particular recipe instance in a Python module (which may
 contain arbitrary numbers of recipe instances) has changed since the last time the instances in
-that module were executed. The file pattern hashes are based on a blockchain built cumulatively
+that module were executed. The file pattern hashes are based on a merkle tree built cumulatively
 from all of the index:filepath pairs yielded by the pattern's `self.items()` method. As such, in
 cases where a new pattern is intended to append to an existing dataset which was built from a
 prior version of that pattern, the pattern hash can be used to determine the index from which to

--- a/pangeo_forge_recipes/patterns.py
+++ b/pangeo_forge_recipes/patterns.py
@@ -258,8 +258,8 @@ class FilePattern:
         """
 
         # we exclude the format function and combine dims from ``root`` because they determine the
-        # index:filepath pairs yielded by iterating over ``.items()``. if these pairs are generated in
-        # a different way in the future, we ultimately don't care.
+        # index:filepath pairs yielded by iterating over ``.items()``. if these pairs are generated
+        # in a different way in the future, we ultimately don't care.
         root = {
             "fsspec_open_kwargs": self.fsspec_open_kwargs,
             "query_string_secrets": self.query_string_secrets,
@@ -295,8 +295,8 @@ class FilePattern:
         ``Index`` key of the current pattern to begin data processing from, in order to append to
         a dataset built using the previous pattern.
 
-        :param old_pattern_last_hash: The last hash of the merkle tree for the ``FilePattern`` instance
-        which was used to build the existing dataset.
+        :param old_pattern_last_hash: The last hash of the merkle tree for the ``FilePattern``
+        instance which was used to build the existing dataset.
         """
         for k, h in zip(self, self.get_merkle_list()):
             if h == old_pattern_last_hash:

--- a/pangeo_forge_recipes/recipes/base.py
+++ b/pangeo_forge_recipes/recipes/base.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field, replace
 from typing import Callable, ClassVar
 
 from ..executors.base import Pipeline
-from ..patterns import FilePattern, prune_pattern
+from ..patterns import FilePattern
 from ..serialization import dataclass_sha256
 from ..storage import StorageConfig, temporary_storage_config
 
@@ -64,7 +64,7 @@ class FilePatternMixin:
         :param nkeep: The number of items to keep from each ConcatDim sequence.
         """
 
-        new_pattern = prune_pattern(self.file_pattern, nkeep=nkeep)
+        new_pattern = self.file_pattern.prune(nkeep=nkeep)
         return replace(self, file_pattern=new_pattern)
 
 

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -10,7 +10,6 @@ from pangeo_forge_recipes.patterns import (
     MergeDim,
     augment_index_with_start_stop,
     pattern_from_file_sequence,
-    prune_pattern,
 )
 from pangeo_forge_recipes.types import IndexedPosition, Position
 
@@ -173,7 +172,7 @@ def test_prune(nkeep, concat_merge_pattern_with_kwargs, runtime_secrets):
         if "query_string_secrets" in runtime_secrets.keys():
             fp.query_string_secrets.update(runtime_secrets["query_string_secrets"])
 
-    fp_pruned = prune_pattern(fp, nkeep=nkeep)
+    fp_pruned = fp.prune(nkeep=nkeep)
     assert fp_pruned.dims == {"variable": 2, "time": nkeep}
     assert len(list(fp_pruned.items())) == 2 * nkeep
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -5,7 +5,7 @@ from typing import Callable
 import pandas as pd
 import pytest
 
-from pangeo_forge_recipes.patterns import ConcatDim, FilePattern, FileType, match_pattern_blockchain
+from pangeo_forge_recipes.patterns import ConcatDim, FilePattern, FileType
 from pangeo_forge_recipes.serialization import dict_to_sha256, either_encode_or_hash
 
 # TODO: revise this test once refactor is farther along
@@ -75,14 +75,14 @@ def pattern_pair(base_pattern, end_date, request):
         (dict(file_type=FileType.opendap), dict(file_type=FileType.opendap)),
     ],
 )
-def test_match_pattern_blockchain(base_pattern, end_date, new_pattern_nitems_per_file, kwargs):
+def test_start_processing_from(base_pattern, end_date, new_pattern_nitems_per_file, kwargs):
     new_pattern, next_url = get_new_pattern_with_next_url(end_date, new_pattern_nitems_per_file)
 
     for i, pattern in enumerate((base_pattern, new_pattern)):
         for k, v in kwargs[i].items():
             setattr(pattern, k, v)
 
-    matching_key = match_pattern_blockchain(base_pattern.sha256(), new_pattern)
+    matching_key = new_pattern.start_processing_from(base_pattern.sha256())
 
     if kwargs[0] == kwargs[1] and new_pattern_nitems_per_file == 1:
         assert new_pattern[matching_key] == next_url


### PR DESCRIPTION
There were 3 useful functions that were free-floating, and turn that into methods of
the `FilePattern` class instead. These methods always operated on `FilePattern` objects,
and took a single param (akin to `self`) plus other args.

It also makes some possible manipulations (ast or otherwise) easier.

This PR also renames some of the `blockchain` methods to refer instead to the
[merkle tree](https://en.wikipedia.org/wiki/Merkle_tree), which is the underlying
data structure used by plenty of things that try to do this kinda structured diff
detection (such as git). I think overall when searching for useful properties of
a datasctructure, 'blockchain' is probably not really useful anymore while
merkle trees are far more useful.