### PR TITLE
Allow target to be str or FSSpecTarget

### DIFF
--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -79,17 +79,20 @@ def _add_keys(func):
 class OpenURLWithFSSpec(beam.PTransform):
     """Open indexed string-based URLs with fsspec.
 
-    :param cache_url: If provided, data will be cached at this url path before opening.
+    :param cache: If provided, data will be cached at this url path before opening.
     :param secrets: If provided these secrets will be injected into the URL as a query string.
     :param open_kwargs: Extra arguments passed to fsspec.open.
     """
 
-    cache_url: Optional[str] = None
+    cache: Optional[str | CacheFSSpecTarget] = None
     secrets: Optional[dict] = None
     open_kwargs: Optional[dict] = None
 
     def expand(self, pcoll):
-        cache = CacheFSSpecTarget.from_url(self.cache_url) if self.cache_url else None
+        if isinstance(self.cache, str):
+            cache = CacheFSSpecTarget.from_url(self.cache)
+        else:
+            cache = self.cache
         return pcoll | "Open with fsspec" >> beam.Map(
             _add_keys(open_url),
             cache=cache,

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -36,7 +36,7 @@ def test_xarray_zarr(
             | beam.Create(pattern.items())
             | OpenWithXarray(file_type=pattern.file_type)
             | StoreToZarr(
-                target_url=tmp_target_url,
+                target=tmp_target_url,
                 target_chunks=target_chunks,
                 combine_dims=pattern.combine_dim_keys,
             )

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -70,7 +70,7 @@ def cache_url(tmp_cache_url, request):
 def pcoll_opened_files(pattern, cache_url):
     input = beam.Create(pattern.items())
     output = input | OpenURLWithFSSpec(
-        cache_url=cache_url,
+        cache=cache_url,
         secrets=pattern.query_string_secrets,
         open_kwargs=pattern.fsspec_open_kwargs,
     )

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -192,7 +192,7 @@ def test_PrepareZarrTarget(pipeline, tmp_target_url, target_chunks):
 
     with pipeline as p:
         input = p | beam.Create([schema])
-        target = input | PrepareZarrTarget(target_url=tmp_target_url, target_chunks=target_chunks)
+        target = input | PrepareZarrTarget(target=tmp_target_url, target_chunks=target_chunks)
         assert_that(target, correct_target())
 
 


### PR DESCRIPTION
The latter allows them to be complex FSSpec objects that can encode information about S3 / GCS, and how they can be authenticated with.