### PR TITLE
Fix broken 0.9.3 release by delaying `kerchunk.netCDF3` import

### DIFF
--- a/pangeo_forge_recipes/reference.py
+++ b/pangeo_forge_recipes/reference.py
@@ -5,7 +5,6 @@ Functions related to creating fsspec references.
 from typing import Dict, Tuple, Union
 
 from kerchunk.hdf import SingleHdf5ToZarr
-from kerchunk.netCDF3 import NetCDF3ToZarr
 
 from .patterns import FileType
 
@@ -16,6 +15,8 @@ def create_kerchunk_reference(
     if file_type == FileType.netcdf4:
         chunks = SingleHdf5ToZarr(fp, url, inline_threshold=inline_threshold)
     elif file_type == FileType.netcdf3:
+        from kerchunk.netCDF3 import NetCDF3ToZarr
+
         chunks = NetCDF3ToZarr(url, max_chunk_size=100_000_000)
     return chunks.translate()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     zarr >= 2.12.0
     numcodecs >= 0.9.0
     fsspec[http] >= 2021.6.0
-    kerchunk >= 0.0.7
+    kerchunk[netcdf3] >= 0.0.7
     mypy_extensions >= 0.4.2
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     zarr >= 2.12.0
     numcodecs >= 0.9.0
     fsspec[http] >= 2021.6.0
-    kerchunk[netcdf3] >= 0.0.7
+    kerchunk >= 0.0.7
     mypy_extensions >= 0.4.2
 
 [options.extras_require]


### PR DESCRIPTION
This recipe test attempted in https://github.com/pangeo-forge/C-iTRACE-feedstock/pull/5#issuecomment-1372985136 failed, and server logs reveal that this issue is that

https://github.com/pangeo-forge/pangeo-forge-recipes/blob/6b29c8aebb0a8a36f8f52ff374972f8a70c0dd6e/pangeo_forge_recipes/reference.py#L8

requires scipy, which we [do not require on install](https://github.com/pangeo-forge/pangeo-forge-recipes/blob/6b29c8aebb0a8a36f8f52ff374972f8a70c0dd6e/setup.cfg#L28-L42). The `kerchunk[netcdf3]` option added in this PR will [bring this in via kerchunk](https://github.com/fsspec/kerchunk/blob/e78f5501ebf562808b8a91ecb1bb69805802eaff/setup.py#L24). The issue can be reproduced by pip-installing `pangeo-forge-recipes==0.9.3` in a blank conda environment, and then:

<details>

```
>>> from pangeo_forge_recipes.recipes import XarryZarrRecipe
Traceback (most recent call last):
  File "/Users/charlesstern/miniconda3/envs/kerchunk-import/lib/python3.9/site-packages/kerchunk/netCDF3.py", line 8, in <module>
    from scipy.io._netcdf import ZERO, NC_VARIABLE, netcdf_file, netcdf_variable
ModuleNotFoundError: No module named 'scipy'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/charlesstern/miniconda3/envs/kerchunk-import/lib/python3.9/site-packages/pangeo_forge_recipes/recipes/__init__.py", line 2, in <module>
    from .reference_hdf_zarr import HDFReferenceRecipe
  File "/Users/charlesstern/miniconda3/envs/kerchunk-import/lib/python3.9/site-packages/pangeo_forge_recipes/recipes/reference_hdf_zarr.py", line 14, in <module>
    from ..reference import create_kerchunk_reference, unstrip_protocol
  File "/Users/charlesstern/miniconda3/envs/kerchunk-import/lib/python3.9/site-packages/pangeo_forge_recipes/reference.py", line 8, in <module>
    from kerchunk.netCDF3 import NetCDF3ToZarr
  File "/Users/charlesstern/miniconda3/envs/kerchunk-import/lib/python3.9/site-packages/kerchunk/netCDF3.py", line 10, in <module>
    raise ImportError(
ImportError: Scipy is required for kerchunking NetCDF3 files. Please install with `pip/conda install scipy`. See https://scipy.org/install/ for more details.
```

</details>

Our CI testing let this through, because scipy is brought into the dev environment those tests run in.