### PR TITLE
Make FSSpecTarget be 'pathlike'

### DIFF
--- a/pangeo_forge_recipes/storage.py
+++ b/pangeo_forge_recipes/storage.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import io
 import json
@@ -11,7 +13,7 @@ import time
 import unicodedata
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Iterator, Optional, Sequence, Union
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
@@ -93,6 +95,14 @@ class FSSpecTarget(AbstractTarget):
 
     fs: fsspec.AbstractFileSystem
     root_path: str = ""
+
+    def __truediv__(self, suffix: str) -> FSSpecTarget:
+        """
+        Support / operator so FSSpecTarget actslike a pathlib.path
+
+        Only supports getting a string suffix added in.
+        """
+        return replace(self, root_path=os.path.join(self.root_path, suffix))
 
     @classmethod
     def from_url(cls, url: str):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -98,3 +98,9 @@ def test_caching_only_truncates_long_fnames_for_local_fs(fs_cls, fname_longer_th
         assert len(fname_in_full_path) == POSIX_MAX_FNAME_LENGTH
     else:
         assert len(fname_in_full_path) > POSIX_MAX_FNAME_LENGTH
+
+
+def test_suffix(tmp_path):
+    assert str((FSSpecTarget(LocalFileSystem(), tmp_path) / "test").root_path) == str(
+        tmp_path / "test"
+    )


### PR DESCRIPTION
The goal here is for recipe authors to be able to
pass *strings* to `target` parameters of StoreToZarr to specify where the data should be for this specific recipe, and we can inject the prefix with pangeo-forge-runner.

The primary use case is when we have a dictionary of recipes being returned from a single recipe file. The *name* of the recipe is unfortunately not really available during AST parsing, so the suffix the data should be put in needs to be explicitly specified.