### PR TITLE
xarray will select backend engine when `FileType.unknown` is specified

### DIFF
--- a/pangeo_forge_recipes/openers.py
+++ b/pangeo_forge_recipes/openers.py
@@ -46,7 +46,7 @@ def _set_engine(file_type, xr_open_kwargs):
     kw = xr_open_kwargs.copy()
     if file_type == FileType.unknown:
         # Enable support for archives containing a mix of e.g. netCDF3 and netCDF4 products etc.
-        warnings.warn(f"Unknown file type specified, backend engine will be automatically selected by xarray")
+        warnings.warn("Unknown file type specified, backend engine will be automatically selected by xarray")
         if "engine" in kw:
             del kw["engine"]
     elif "engine" in kw:

--- a/pangeo_forge_recipes/openers.py
+++ b/pangeo_forge_recipes/openers.py
@@ -45,12 +45,12 @@ OPENER_MAP = {
 def _set_engine(file_type, xr_open_kwargs):
     kw = xr_open_kwargs.copy()
     if file_type == FileType.unknown:
-        # Enable support for archives containing a mix of e.g. netCDF3 and netCDF4 products etc.
-        warnings.warn(
-            "Unknown file type specified, backend engine will be automatically selected by xarray"
-        )
-        if "engine" in kw:
-            del kw["engine"]
+        # Enable support for archives containing a mix of types e.g. netCDF3 and netCDF4 products
+        if "engine" not in kw:
+            warnings.warn(
+                "Unknown file type specified without xarray engine, "
+                "backend engine will be automatically selected by xarray"
+            )
     elif "engine" in kw:
         engine_message_base = (
             "pangeo-forge-recipes will automatically set the xarray backend for "

--- a/pangeo_forge_recipes/openers.py
+++ b/pangeo_forge_recipes/openers.py
@@ -25,7 +25,6 @@ def open_url(
     :param secrets: If provided these secrets will be injected into the URL as a query string.
     :param open_kwargs: Extra arguments passed to fsspec.open.
     """
-
     kw = open_kwargs or {}
     if cache is not None:
         # this has side effects
@@ -45,7 +44,12 @@ OPENER_MAP = {
 
 def _set_engine(file_type, xr_open_kwargs):
     kw = xr_open_kwargs.copy()
-    if "engine" in kw:
+    if file_type == FileType.unknown:
+        # Enable support for archives containing a mix of e.g. netCDF3 and netCDF4 products etc.
+        warnings.warn(f"Unknown file type specified, backend engine will be automatically selected by xarray")
+        if "engine" in kw:
+            del kw["engine"]
+    elif "engine" in kw:
         engine_message_base = (
             "pangeo-forge-recipes will automatically set the xarray backend for "
             f"files of type '{file_type.value}' to '{OPENER_MAP[file_type]}', "

--- a/tests/test_openers.py
+++ b/tests/test_openers.py
@@ -106,7 +106,7 @@ def is_valid_dataset(ds, in_memory=False):
         raise AssertionError(f"The following vars {msg}: {offending_vars}")
 
 
-def test_open_file_with_xarray(url_and_type, cache, load, copy_to_local, xarray_open_kwargs):
+def validate_open_file_with_xarray(url_and_type, cache, load, copy_to_local, xarray_open_kwargs):
     # open fsspec OpenFile objects
     url, kwargs, file_type = url_and_type
     open_file = open_url(url, cache=cache, **kwargs)
@@ -120,6 +120,28 @@ def test_open_file_with_xarray(url_and_type, cache, load, copy_to_local, xarray_
     )
     validate_fn(ds)
     is_valid_dataset(ds, in_memory=load)
+
+
+def test_open_file_with_xarray(url_and_type, cache, load, copy_to_local, xarray_open_kwargs):
+    validate_open_file_with_xarray(url_and_type=url_and_type,
+                                   cache=cache,
+                                   load=load,
+                                   copy_to_local=copy_to_local,
+                                   xarray_open_kwargs=xarray_open_kwargs
+    )
+
+
+def test_open_file_with_xarray_unknown_filetype(url_and_type, cache, load, copy_to_local, xarray_open_kwargs):
+    # Ignore the specified file_type
+    url, kwargs, _ = url_and_type
+    # Specifying unknown file_type should ensure xarray automatically
+    # selects the backend engine
+    validate_open_file_with_xarray(url_and_type=(url, kwargs, FileType.unknown),
+                                   cache=cache,
+                                   load=load,
+                                   copy_to_local=copy_to_local,
+                                   xarray_open_kwargs=xarray_open_kwargs
+    )
 
 
 def test_direct_open_with_xarray(public_url_and_type, load, xarray_open_kwargs):


### PR DESCRIPTION
Fixes #472 

When `FileType.unknown` is specified in an `OpenWithXarray` transform, `engine` is removed from `OpenWithXarray.xarray_open_kwargs`, which ensures xarray will automatically select the backend engine when opening each recipe file. This enables support for recipes containing a mix of types e.g. netCDF3 and netCDF4.

