### PR TITLE
Docs/sphinx downgrade

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx<5
+sphinx<7
 pangeo-sphinx-book-theme>=0.2
 myst-parser
 myst-nb

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx<7
+sphinx<5
 pangeo-sphinx-book-theme>=0.2
 myst-parser
 myst-nb


### PR DESCRIPTION
Reverts https://github.com/pangeo-forge/pangeo-forge-recipes/pull/461 to downgrade Sphinx from <7 to <5.  Possible fix for https://github.com/pangeo-forge/pangeo-forge-recipes/issues/477.