### PR TITLE
Test python 3.9 and 3.10, not 3.8 and 3.9

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.9", "3.10"]
         dependencies: ["releases-only", "upstream-dev"]
     steps:
       - uses: actions/checkout@v2
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.9", "3.10"]
         dependencies: ["releases-only", "upstream-dev"]
         pytest-mark: ["no_executor"]
         # pytest-mark: ["no_executor", "executor_function", "executor_generator", "executor_beam"]

--- a/ci/py3.10.yml
+++ b/ci/py3.10.yml
@@ -2,7 +2,7 @@ name: pangeo-forge-recipes
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
+  - python=3.10
   - aiohttp
   - apache-beam
   - black
@@ -14,13 +14,15 @@ dependencies:
   - distributed
   - fsspec>=2022.1.0
   - gcsfs>=2022.1.0
+  - graphviz  # needed for building tutorial notebooks
   - h5netcdf
-  # can't solve environment; moved to pip
-  # - h5py>=3.3.0  - hdf5
+  - h5py>=3.3.0
+  - hdf5
   - intake
   - intake-xarray
   - kerchunk>=0.0.6
-  - lxml
+  - lxml    # Optional dep of pydap
+  - matplotlib  # needed for building tutorial notebooks
   - netcdf4
   - numcodecs
   - numpy
@@ -28,24 +30,23 @@ dependencies:
   - pip
   - prefect==1.3.0
   - pydap
-  # bring back eventually once pynio conda-forge package does not conflict
-  # with ujson, which is a depencency of kerchunk's conda-forge feedstock.
+  # bring back eventually once pynio conda-forge package supports py3.9 and does not
+  # conflict with ujson, which is a depencency of kerchunk's conda-forge feedstock.
   # See: https://github.com/conda-forge/pynio-feedstock/issues/114
-  # - pynio
+  #  - pynio
   - pytest
   - pytest-cov
   - pytest-lazy-fixture
+  - python-graphviz  # needed for building tutorial notebooks
   - rasterio
   - requests
   - rechunker>=0.4.2
-  - s3fs>=2022.1.0
   - scipy
+  - s3fs>=2022.1.0
   - setuptools
   - toolz
   - xarray>=0.18.0
   - zarr>=2.6.0
-  - pytest-repeat
-  - pip
   - pip:
-    - h5py>=3.3.0
+    - nbmake>=1.3.0  # used in tutorial nb worklow
     - pytest-timeout


### PR DESCRIPTION
Based on
https://docs.xarray.dev/en/stable/whats-new.html#breaking-changes, xarray's latest version no longer supports Python 3.8. This causes test to fail in
https://github.com/pangeo-forge/pangeo-forge-recipes/pull/489.

So we bump up to 3.9 and 3.10!