### PR TITLE
Add store_name to StoreToZarr

### DIFF
--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -268,9 +268,9 @@ class StoreToZarr(beam.PTransform):
     """Store a PCollection of Xarray datasets to Zarr.
 
     :param combine_dims: The dimensions to combine
-    :param target: Where to store the target Zarr dataset.
-    :param target_subpath: Subpath *inside* the target to store this Zarr dataset.
-                           Useful when generating multiple Zarr datasets from the same recipe.
+    :param target: Location that will contain the target Zarr Store.
+    :param store_name: Name for the Zarr store. It will be created with this name
+                       under `target`.
     :param target_chunks: Dictionary mapping dimension names to chunks sizes.
         If a dimension is a not named, the chunks will be inferred from the data.
     """
@@ -279,7 +279,7 @@ class StoreToZarr(beam.PTransform):
     # Could be inferred from the pattern instead
     combine_dims: List[Dimension]
     target: str | FSSpecTarget
-    target_subpath: Optional[str] = None
+    store_name: str
     target_chunks: Dict[str, int] = field(default_factory=dict)
 
     def expand(self, datasets: beam.PCollection) -> beam.PCollection:
@@ -289,10 +289,7 @@ class StoreToZarr(beam.PTransform):
             target_root = FSSpecTarget.from_url(self.target)
         else:
             target_root = self.target
-        if self.target_subpath:
-            full_target = target_root / self.target_subpath
-        else:
-            full_target = target_root
+        full_target = target_root / self.store_name
         target_store = schema | PrepareZarrTarget(
             target=full_target, target_chunks=self.target_chunks
         )

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -268,9 +268,9 @@ class StoreToZarr(beam.PTransform):
     """Store a PCollection of Xarray datasets to Zarr.
 
     :param combine_dims: The dimensions to combine
-    :param target: Location that will contain the target Zarr Store.
+    :param target_root: Location the Zarr store will be created inside.
     :param store_name: Name for the Zarr store. It will be created with this name
-                       under `target`.
+                       under `target_root`.
     :param target_chunks: Dictionary mapping dimension names to chunks sizes.
         If a dimension is a not named, the chunks will be inferred from the data.
     """
@@ -278,17 +278,17 @@ class StoreToZarr(beam.PTransform):
     # TODO: make it so we don't have to explictly specify combine_dims
     # Could be inferred from the pattern instead
     combine_dims: List[Dimension]
-    target: str | FSSpecTarget
+    target_root: str | FSSpecTarget
     store_name: str
     target_chunks: Dict[str, int] = field(default_factory=dict)
 
     def expand(self, datasets: beam.PCollection) -> beam.PCollection:
         schema = datasets | DetermineSchema(combine_dims=self.combine_dims)
         indexed_datasets = datasets | IndexItems(schema=schema)
-        if isinstance(self.target, str):
-            target_root = FSSpecTarget.from_url(self.target)
+        if isinstance(self.target_root, str):
+            target_root = FSSpecTarget.from_url(self.target_root)
         else:
-            target_root = self.target
+            target_root = self.target_root
         full_target = target_root / self.store_name
         target_store = schema | PrepareZarrTarget(
             target=full_target, target_chunks=self.target_chunks

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,3 +1,5 @@
+import os
+
 import apache_beam as beam
 import pytest
 import xarray as xr
@@ -44,4 +46,27 @@ def test_xarray_zarr(
 
     ds = xr.open_dataset(tmp_target_url, engine="zarr")
     assert ds.time.encoding["chunks"] == (target_chunks["time"],)
+    xr.testing.assert_equal(ds.load(), daily_xarray_dataset)
+
+
+def test_xarray_zarr_subpath(
+    daily_xarray_dataset,
+    netcdf_local_file_pattern_sequential,
+    pipeline,
+    tmp_target_url,
+):
+    pattern = netcdf_local_file_pattern_sequential
+    with pipeline as p:
+        (
+            p
+            | beam.Create(pattern.items())
+            | OpenWithXarray(file_type=pattern.file_type)
+            | StoreToZarr(
+                target=tmp_target_url,
+                target_subpath="subpath",
+                combine_dims=pattern.combine_dim_keys,
+            )
+        )
+
+    ds = xr.open_dataset(os.path.join(tmp_target_url, "subpath"), engine="zarr")
     xr.testing.assert_equal(ds.load(), daily_xarray_dataset)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -38,7 +38,7 @@ def test_xarray_zarr(
             | beam.Create(pattern.items())
             | OpenWithXarray(file_type=pattern.file_type)
             | StoreToZarr(
-                target=tmp_target_url,
+                target_root=tmp_target_url,
                 store_name="store",
                 target_chunks=target_chunks,
                 combine_dims=pattern.combine_dim_keys,
@@ -63,7 +63,7 @@ def test_xarray_zarr_subpath(
             | beam.Create(pattern.items())
             | OpenWithXarray(file_type=pattern.file_type)
             | StoreToZarr(
-                target=tmp_target_url,
+                target_root=tmp_target_url,
                 store_name="subpath",
                 combine_dims=pattern.combine_dim_keys,
             )

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -39,12 +39,13 @@ def test_xarray_zarr(
             | OpenWithXarray(file_type=pattern.file_type)
             | StoreToZarr(
                 target=tmp_target_url,
+                store_name="store",
                 target_chunks=target_chunks,
                 combine_dims=pattern.combine_dim_keys,
             )
         )
 
-    ds = xr.open_dataset(tmp_target_url, engine="zarr")
+    ds = xr.open_dataset(os.path.join(tmp_target_url, "store"), engine="zarr")
     assert ds.time.encoding["chunks"] == (target_chunks["time"],)
     xr.testing.assert_equal(ds.load(), daily_xarray_dataset)
 
@@ -63,7 +64,7 @@ def test_xarray_zarr_subpath(
             | OpenWithXarray(file_type=pattern.file_type)
             | StoreToZarr(
                 target=tmp_target_url,
-                target_subpath="subpath",
+                store_name="subpath",
                 combine_dims=pattern.combine_dim_keys,
             )
         )


### PR DESCRIPTION
When generating multiple Zarr datasets from the same recipe, we want to support specifying *where* each dataset will go inside the same target, as target is set by pangeo-forge-runner. Without, this subpath is specified as the *name* of the recipe itself. However, due to how ast rewriting works, we don't actually have the name of the recipe when constructing our beam pipeline, so we can not use that. So instead, it would have to be explicitly specified as a subpath inside the target.