### PR TITLE
Port Recipes User Guide to `beam-refactor`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ There are a number of resources available when working with Pangeo Forge:
 - **Introduction Tutorial**: {doc}`introduction_tutorial/index` - Walks you through creating, running, and staging your first Recipe.
 - **User Guides** explain core Pangeo Forge concepts in detail. They provide
   background information to aid in gaining a depth of understanding:
-  - {doc}`pangeo_forge_recipes/recipe_user_guide/index` - For learning about how to create Recipes.
+  - {doc}`pangeo_forge_recipes/recipe_user_guide/index` - For learning about how to create Recipes. A recipe is defined as a [pipeline](https://beam.apache.org/documentation/programming-guide/#creating-a-pipeline) of [Apache Beam](https://beam.apache.org/) [transforms](https://beam.apache.org/documentation/programming-guide/#transforms) applied to a data collection, performing one or more transformations of input elements to output elements.
   - {doc}`pangeo_forge_cloud/recipe_contribution` - For learning how to contribute recipes to Pangeo Forge Cloud.
   - {doc}`pangeo_forge_recipes/development/development_guide` - For developers seeking to contribute to Pangeo Forge core functionality.
 - **Advanced Examples** walk through examples of using Pangeo Forge Recipes:

--- a/docs/pangeo_forge_recipes/recipe_user_guide/execution.md
+++ b/docs/pangeo_forge_recipes/recipe_user_guide/execution.md
@@ -11,39 +11,19 @@ recipe has already been initialized in the variable `recipe`.
 
 ## Recipe Executors
 
-```{note}
-API reference documentation for execution can be found in {mod}`pangeo_forge_recipes.executors`.
-```
-
 A recipe is an abstract description of a transformation pipeline.
-Recipes can be _compiled_ to executable objects.
-We currently support three types of compilation.
-
-### Python Function
-
-To compile a recipe to a single python function, use the method `.to_function()`.
-For example
-
-```{code-block} python
-recipe_func = recipe.to_function()
-recipe_func()  # actually execute the recipe
-```
-
-Note that the python function approach does not support parallel or distributed execution.
-It's mostly just a convenience utility.
+We currently support the following execution mechanism.
 
 ### Beam PTransform
 
-You can compile your recipe to an Apache Beam [PTransform](https://beam.apache.org/documentation/programming-guide/#transforms)
-to be used within a [Pipeline](https://beam.apache.org/documentation/programming-guide/#creating-a-pipeline) using the
-:meth:`BaseRecipe.to_beam()` method. For example
+A recipe is defined as a [pipeline](https://beam.apache.org/documentation/programming-guide/#creating-a-pipeline) of [Apache Beam transforms](https://beam.apache.org/documentation/programming-guide/#transforms) applied to the data collection associated with a {doc}`file pattern <file_patterns>`. Specifically, each recipe pipeline contains a set of transforms that operate on an `apache_beam.PCollection`, applying the specified transformation from input to output elements. Having created a transforms pipeline (see {doc}`recipes`}, it may be executed with Beam as follows:
 
 ```{code-block} python
 import apache_beam as beam
 
 with beam.Pipeline() as p:
-   p | recipe.to_beam()
+    p | transforms
 ```
 
 By default the pipeline runs using Beam's [DirectRunner](https://beam.apache.org/documentation/runners/direct/).
-See [runners](https://beam.apache.org/documentation/#runners) for more.
+See [runners](https://beam.apache.org/documentation/#runners) for more details.

--- a/docs/pangeo_forge_recipes/recipe_user_guide/execution.md
+++ b/docs/pangeo_forge_recipes/recipe_user_guide/execution.md
@@ -25,5 +25,9 @@ with beam.Pipeline() as p:
     p | transforms
 ```
 
-By default the pipeline runs using Beam's [DirectRunner](https://beam.apache.org/documentation/runners/direct/).
-See [runners](https://beam.apache.org/documentation/#runners) for more details.
+By default the pipeline runs using Beam's [DirectRunner](https://beam.apache.org/documentation/runners/direct/), which is useful during recipe development. However, alternative Beam runners are available, for example:
+* [FlinkRunner](https://beam.apache.org/documentation/runners/flink/): execute Beam pipelines using [Apache Flink](https://flink.apache.org/).
+* [DataflowRunner](https://beam.apache.org/documentation/runners/dataflow/): uses the [Google Cloud Dataflow managed service](https://cloud.google.com/dataflow/service/dataflow-service-desc).
+* [DaskRunner](https://beam.apache.org/releases/pydoc/current/apache_beam.runners.dask.dask_runner.html): executes pipelines via [Dask.distributed](https://distributed.dask.org/en/stable/).
+
+See [here](https://beam.apache.org/documentation/#runners) for details of the available Beam runners.

--- a/docs/pangeo_forge_recipes/recipe_user_guide/recipes.md
+++ b/docs/pangeo_forge_recipes/recipe_user_guide/recipes.md
@@ -21,7 +21,7 @@ to {doc}`../../pangeo_forge_cloud/index`, which allows the recipe to be automati
 
 ## Recipe Pipelines
 
-A recipe is defined as a pipeline of [Apache Beam transforms](https://beam.apache.org/documentation/programming-guide/#transforms) applied to the data collection associated with a {doc}`file pattern <file_patterns>`. Specifically, each recipe pipeline contains a set of transforms, which operate on an `apache_beam.PCollection`, performing a one-to-one mapping using `apache_beam.Map` of input elements to output elements, applying the specified transformation.
+A recipe is defined as a [pipeline](https://beam.apache.org/documentation/programming-guide/#creating-a-pipeline) of [Apache Beam transforms](https://beam.apache.org/documentation/programming-guide/#transforms) applied to the data collection associated with a {doc}`file pattern <file_patterns>`. Specifically, each recipe pipeline contains a set of transforms, which operate on an `apache_beam.PCollection`, performing a one-to-one mapping using `apache_beam.Map` of input elements to output elements, applying the specified transformation.
 
 To write a recipe, you define a pipeline that uses existing transforms, in combination with new transforms if required for custom processing of the input data collection.
 

--- a/docs/pangeo_forge_recipes/recipe_user_guide/recipes.md
+++ b/docs/pangeo_forge_recipes/recipe_user_guide/recipes.md
@@ -19,23 +19,24 @@ Recipe authors (i.e. data users or data managers) can either execute their recip
 on their own computers and infrastructure, in private, or make a {doc}`../../pangeo_forge_cloud/recipe_contribution`
 to {doc}`../../pangeo_forge_cloud/index`, which allows the recipe to be automatically by via [Bakeries](../../pangeo_forge_cloud/core_concepts.md).
 
-## Recipe Classes
+## Recipe Pipelines
 
-To write a recipe, you must start from one of the existing recipe classes.
-Recipe classes are based on a specific data model for the input files and target dataset format.
-Right now, there are two distinct recipe classes implemented.
+A recipe is defined as a pipeline of [Apache Beam transforms](https://beam.apache.org/documentation/programming-guide/#transforms) applied to the data collection associated with a {doc}`file pattern <file_patterns>`. Specifically, each recipe pipeline contains a set of transforms, which operate on an `apache_beam.PCollection`, performing a one-to-one mapping using `apache_beam.Map` of input elements to output elements, applying the specified transformation.
+
+To write a recipe, you define a pipeline that uses existing transforms, in combination with new transforms if required for custom processing of the input data collection.
+
+Right now, there are two categories of recipe pipelines based on a specific data model for the input files and target dataset format.
 In the future, we may add more.
 
-TODO add rubric for choosing a recipe class.
-
-### XarrayZarr Recipe
-
 ```{note}
-The full API Reference documentation for this recipe class can be found at
-{class}`pangeo_forge_recipes.recipes.XarrayZarrRecipe`
+The full API Reference documentation for the existing recipe `PTransform` implementations can be found at
+{doc}`../api_reference`.
 ```
 
-The {class}`pangeo_forge_recipes.recipes.XarrayZarrRecipe` recipe class uses
+### Xarray to Zarr Recipes
+
+
+This recipe category uses
 [Xarray](http://xarray.pydata.org/) to read the input files and
 [Zarr](https://zarr.readthedocs.io/) as the target dataset format.
 The inputs can be in any [file format Xarray can read](http://xarray.pydata.org/en/latest/user-guide/io.html),
@@ -48,7 +49,7 @@ The target Zarr dataset will conform to the
 [Xarray Zarr encoding conventions](http://xarray.pydata.org/en/latest/internals/zarr-encoding-spec.html).
 
 The best way to really understand how recipes work is to go through the relevant
-tutorials for this recipe class. These are, in order of increasing complexity
+tutorials for this recipe category. These are, in order of increasing complexity
 
 - {doc}`../tutorials/xarray_zarr/netcdf_zarr_sequential`
 - {doc}`../tutorials/xarray_zarr/cmip6-recipe`
@@ -59,29 +60,43 @@ tutorials for this recipe class. These are, in order of increasing complexity
 Below we give a very basic overview of how this recipe is used.
 
 First you must define a {doc}`file pattern <file_patterns>`.
-Once you have a {class}`file_pattern <pangeo_forge_recipes.patterns.FilePattern>` object,
-initializing an `XarrayZarrRecipe` can be as simple as this.
+Once you have a {class}`FilePattern <pangeo_forge_recipes.patterns.FilePattern>` object,
+the recipe pipeline will contain at a minimum the following transforms applied to the file pattern collection:
+* `OpenURLWithFSSpec`: retrieves each pattern file using the specified URLs.
+* `OpenWithXarray`: load each pattern file into an `xarray.Dataset`:
+  * The `file_type` is specified from the pattern.
+* `StoreToZarr`: generate a Zarr store by combining the datasets:
+  * `store_name` specifies the name of the generated Zarr store.
+  * `target_root` specifies where the output will be stored, in this case, the temporary directory we created.
+  * `combine_dims` informs the transform of the dimension used to combine the datasets. Here we use the dimension specified in the file pattern (`time`).
+  * `target_chunks`: specifies a dictionary of required chunk size per dimension. In the event that this is not specified for a particular dimension, it will default to the corresponding full shape.
 
+For example:
 ```{code-block} python
-recipe = XarrayZarrRecipe(file_pattern)
+transforms = (
+    beam.Create(pattern.items())
+    | OpenURLWithFSSpec()
+    | OpenWithXarray(file_type=pattern.file_type)
+    | StoreToZarr(
+        store_name=store_name,
+        target_root=target_root,
+        combine_dims=pattern.combine_dim_keys,
+        target_chunks={"time": 10}
+    )
+)
 ```
 
-There are many other options we could pass, all covered in the {class}`API documentation <pangeo_forge_recipes.recipes.XarrayZarrRecipe>`. Many of these options are explored further in the {doc}`../tutorials/index`.
+The available transform options are all covered in the {doc}`../api_reference`. Many of these options are explored further in the {doc}`../tutorials/index`.
 
 All recipes need a place to store the target dataset. Refer to {doc}`storage` for how to assign this and any other required storage targets.
 
 Once your recipe is defined and has its storage targets assigned, you're ready to
 move on to {doc}`execution`.
 
-### HDF Reference Recipe
+### HDF Reference Recipes
 
-```{note}
-The full API Reference documentation for this recipe class can be found at
-{class}`pangeo_forge_recipes.recipes.HDFReferenceRecipe`
-```
-
-Like the `XarrayZarrRecipe`, this recipe allows us to more efficiently access data from a bunch of NetCDF / HDF files.
-However, this recipe does not actually copy the original source data.
+Like the Xarray to Zarr recipes, this category allows us to more efficiently access data from a bunch of NetCDF / HDF files.
+However, such a recipe does not actually copy the original source data.
 Instead, it generates metadata files which reference and index the original data, allowing it to be accessed more quickly and easily.
 For more background, see [this blog post](https://medium.com/pangeo/fake-it-until-you-make-it-reading-goes-netcdf4-data-on-aws-s3-as-zarr-for-rapid-data-access-61e33f8fe685).
 

--- a/docs/pangeo_forge_recipes/recipe_user_guide/recipes.md
+++ b/docs/pangeo_forge_recipes/recipe_user_guide/recipes.md
@@ -21,7 +21,7 @@ to {doc}`../../pangeo_forge_cloud/index`, which allows the recipe to be automati
 
 ## Recipe Pipelines
 
-A recipe is defined as a [pipeline](https://beam.apache.org/documentation/programming-guide/#creating-a-pipeline) of [Apache Beam transforms](https://beam.apache.org/documentation/programming-guide/#transforms) applied to the data collection associated with a {doc}`file pattern <file_patterns>`. Specifically, each recipe pipeline contains a set of transforms, which operate on an `apache_beam.PCollection`, performing a one-to-one mapping using `apache_beam.Map` of input elements to output elements, applying the specified transformation.
+A recipe is defined as a [pipeline](https://beam.apache.org/documentation/programming-guide/#creating-a-pipeline) of [Apache Beam transforms](https://beam.apache.org/documentation/programming-guide/#transforms) applied to the data collection associated with a {doc}`file pattern <file_patterns>`. Specifically, each recipe pipeline contains a set of transforms, which operate on an [`apache_beam.PCollection`](https://beam.apache.org/documentation/programming-guide/#pcollections), performing a mapping of input elements to output elements (for example, using [`apache_beam.Map`](https://beam.apache.org/documentation/transforms/python/elementwise/map/)), applying the specified transformation.
 
 To write a recipe, you define a pipeline that uses existing transforms, in combination with new transforms if required for custom processing of the input data collection.
 
@@ -29,7 +29,7 @@ Right now, there are two categories of recipe pipelines based on a specific data
 In the future, we may add more.
 
 ```{note}
-The full API Reference documentation for the existing recipe `PTransform` implementations can be found at
+The full API Reference documentation for the existing recipe `PTransform` implementations ({class}`pangeo_forge_recipes.transforms`) can be found at
 {doc}`../api_reference`.
 ```
 
@@ -62,10 +62,10 @@ Below we give a very basic overview of how this recipe is used.
 First you must define a {doc}`file pattern <file_patterns>`.
 Once you have a {class}`FilePattern <pangeo_forge_recipes.patterns.FilePattern>` object,
 the recipe pipeline will contain at a minimum the following transforms applied to the file pattern collection:
-* `OpenURLWithFSSpec`: retrieves each pattern file using the specified URLs.
-* `OpenWithXarray`: load each pattern file into an `xarray.Dataset`:
+* {class}`pangeo_forge_recipes.transforms.OpenURLWithFSSpec`: retrieves each pattern file using the specified URLs.
+* {class}`pangeo_forge_recipes.transforms.OpenWithXarray`: load each pattern file into an [`xarray.Dataset`](https://docs.xarray.dev/en/stable/generated/xarray.Dataset.html):
   * The `file_type` is specified from the pattern.
-* `StoreToZarr`: generate a Zarr store by combining the datasets:
+* {class}`pangeo_forge_recipes.transforms.StoreToZarr`: generate a Zarr store by combining the datasets:
   * `store_name` specifies the name of the generated Zarr store.
   * `target_root` specifies where the output will be stored, in this case, the temporary directory we created.
   * `combine_dims` informs the transform of the dimension used to combine the datasets. Here we use the dimension specified in the file pattern (`time`).

--- a/docs/pangeo_forge_recipes/recipe_user_guide/storage.md
+++ b/docs/pangeo_forge_recipes/recipe_user_guide/storage.md
@@ -50,7 +50,7 @@ transforms = (
     | OpenURLWithFSSpec()
     | OpenWithXarray(file_type=pattern.file_type)
     | StoreToZarr(
-        store_name=my-dataset-v1.zarr,
+        store_name="my-dataset-v1.zarr",
         target_root=target_root,
         combine_dims=pattern.combine_dim_keys,
         target_chunks={"time": 10}
@@ -74,7 +74,7 @@ transforms = (
     | OpenURLWithFSSpec(cache=cache)
     | OpenWithXarray(file_type=pattern.file_type)
     | StoreToZarr(
-        store_name=my-dataset-v1.zarr,
+        store_name="my-dataset-v1.zarr",
         target_root=target_root,
         combine_dims=pattern.combine_dim_keys,
         target_chunks={"time": 10}

--- a/docs/pangeo_forge_recipes/tutorials/index.md
+++ b/docs/pangeo_forge_recipes/tutorials/index.md
@@ -12,4 +12,3 @@ xarray_zarr/terraclimate
 xarray_zarr/opendap_subset_recipe
 hdf_reference/reference_cmip6
 ```
-

--- a/docs/pangeo_forge_recipes/tutorials/index.md
+++ b/docs/pangeo_forge_recipes/tutorials/index.md
@@ -9,7 +9,7 @@ xarray_zarr/netcdf_zarr_sequential
 xarray_zarr/cmip6-recipe
 xarray_zarr/multi_variable_recipe
 xarray_zarr/terraclimate
+xarray_zarr/opendap_subset_recipe
 hdf_reference/reference_cmip6
 ```
 
-[//]: # (TODO - Restore this in previous toctree if/when XarrayZarrRecipe.subset_inputs is supported on Beam, https://github.com/pangeo-forge/pangeo-forge-recipes/issues/496: xarray_zarr/opendap_subset_recipe)


### PR DESCRIPTION
This PR ports the *Recipe Users Guide* section of the documentation to use the `beam-refactor` implementation. 
* I've retained the original text/flow as much as possible, where Beam content has been taken from the tutorial notebooks (#487).
* The *HDF Reference Recipes* section has been retained for now, but we may exclude it if the corresponding tutorial notebook isn't ported before release.