### PR TITLE
Factor prepare-env workflow into reusable/standalone file

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,28 +13,6 @@ on:
 env:
   PYTEST_ADDOPTS: "--color=yes"
 
-# This is a pretty complicated workflow. The reason it is this way is that it
-# has been optimized to go fast fast. The specific optimizations are
-#
-# ## Environment building and caching ("prepare-env" job)
-#
-#    This step builds and caches the test environments using conda.
-#    If there is no cache, building each environment takes 3-4 minutes.
-#    If there is a cache this step should take about 40 seconds.
-#    (The time needed to install conda and check the cache.)
-#
-#    The cache key is as follows:
-#    ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles( env.env_file ) }}-${{ env.CACHE_NUMBER }}
-#
-#    A key parameter env.CACHE_NUMBER. This is a number that is set based on the current date:
-#    CACHE_NUMBER=`expr $(date +'%j') / 3`
-#    This is designed such that the cached environment will be reused for maximum 3 days.
-#    After 3 days, the CACHE_NUMBER will increment, forcing a new environment to be built.
-#    This cadence was chosen as a balance between making the tests go fast
-#    (avoiding rebuilding environments every run), and using a fresh, recent environment.
-#
-#    The test environment is cached in /usr/share/miniconda3/envs/pangeo-forge-recipes
-#
 # ## Running the tests ("run-tests" job)
 #
 #    This step does not even attempt to build environments. It just loads them from the cache.
@@ -46,50 +24,7 @@ env:
 
 jobs:
   prepare-env:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.9", "3.10"]
-        dependencies: ["releases-only", "upstream-dev"]
-    steps:
-      - uses: actions/checkout@v2
-      - name: 🔁 Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: x64
-      - name: 🔁 Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          activate-environment: pangeo-forge-recipes
-          use-mamba: true
-      - name: 🎯 Set cache number
-        id: cache-number
-        # cache will last 3 days by default
-        run: echo CACHE_NUMBER=`expr $(date +'%j') / 3` >> $GITHUB_ENV
-      - name: 🎯 Set environment file
-        id: env-file
-        run: echo "env_file=ci/py${{ matrix.python-version }}.yml" >> $GITHUB_ENV
-      - uses: actions/cache@v2
-        name: 🗃 Cache environment
-        with:
-          path: /usr/share/miniconda3/envs/pangeo-forge-recipes
-          key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles( env.env_file ) }}-${{ matrix.dependencies }}-${{ env.CACHE_NUMBER }}
-        id: conda-cache
-      - name: 🐫 Maybe Update environment
-        if: steps.conda-cache.outputs.cache-hit != 'true'
-        run: mamba env update -n pangeo-forge-recipes -f ${{ env.env_file }}
-      - name: 🧑‍💻 Maybe update to upstream dev versions
-        if: matrix.dependencies == 'upstream-dev'
-        run: mamba env update -n pangeo-forge-recipes -f ci/upstream-dev.yml
-      - name: 🐍 List conda env
-        shell: bash -l {0}
-        run: |
-          conda info
-          conda list
+    uses: ./.github/workflows/prepare-env.yaml
   run-tests:
     needs: prepare-env
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,14 +13,21 @@ on:
 env:
   PYTEST_ADDOPTS: "--color=yes"
 
-# ## Running the tests ("run-tests" job)
+# This our primary testing workflow.
 #
-#    This step does not even attempt to build environments. It just loads them from the cache.
-#    Then it adds the following path to $PATH
-#    /usr/share/miniconda3/envs/pangeo-forge-recipes/bin
+# It also serves as an example for how to reference the separate prepare-env workflow.
+# This workflow does not even attempt to build environments. It dispatches that resposibility
+# to the prepare-env workflow and then loads the environments which that workflow has cached.
 #
-#    We use pytest marks to parallelize execution across the different executors.
-#    These marks are configured in tests/conftest.py
+# Note that all of the steps listed under the comment ``# generic steps to load env from cache``
+# are required to load the environment. They include:
+#   - Generating the cache key
+#   - Actually loading the environment using the key
+#   - Adding the path ``/usr/share/miniconda3/envs/pangeo-forge-recipes/bin`` to $PATH
+#
+# Apart from the caching logic, we use pytest marks to parallelize execution across different
+# executors. These marks are configured in tests/conftest.py, and represent a testing regime
+# which pre-dates the beam-refactor. We may want to deprecate them.
 
 jobs:
   prepare-env:
@@ -42,6 +49,8 @@ jobs:
             pytest-mark: "executor_generator"
     steps:
       - uses: actions/checkout@v2
+
+      # generic steps to load env from cache
       - name: 🎯 Set cache number
         id: cache-number
         # cache will last 3 days by default
@@ -60,6 +69,8 @@ jobs:
         run: false
       - name: 🎯 Set path to include conda python
         run: echo "/usr/share/miniconda3/envs/pangeo-forge-recipes/bin" >> $GITHUB_PATH
+
+      # custom testing steps unique to this workflow
       - name: 🌈 Install pangeo-forge-recipes package
         shell: bash -l {0}
         run: |

--- a/.github/workflows/prepare-env.yaml
+++ b/.github/workflows/prepare-env.yaml
@@ -12,7 +12,7 @@ on:
 # ** How do I use it? **
 #
 #   To load a cached environment built by this workflow in another workflow, please refer to
-#   main.yaml in this directory, which demonstrates the proper use.
+#   main.yaml in this directory, which demonstrates its proper use.
 #
 # ** Details **
 #

--- a/.github/workflows/prepare-env.yaml
+++ b/.github/workflows/prepare-env.yaml
@@ -1,0 +1,73 @@
+name: Prepare env
+
+on:
+  workflow_call:
+
+# This is a pretty complicated workflow. The reason it is this way is that it
+# has been optimized to go fast fast. The specific optimizations are
+#
+# ## Environment building and caching ("prepare-env" job)
+#
+#    This step builds and caches the test environments using conda.
+#    If there is no cache, building each environment takes 3-4 minutes.
+#    If there is a cache this step should take about 40 seconds.
+#    (The time needed to install conda and check the cache.)
+#
+#    The cache key is as follows:
+#    ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles( env.env_file ) }}-${{ env.CACHE_NUMBER }}
+#
+#    A key parameter env.CACHE_NUMBER. This is a number that is set based on the current date:
+#    CACHE_NUMBER=`expr $(date +'%j') / 3`
+#    This is designed such that the cached environment will be reused for maximum 3 days.
+#    After 3 days, the CACHE_NUMBER will increment, forcing a new environment to be built.
+#    This cadence was chosen as a balance between making the tests go fast
+#    (avoiding rebuilding environments every run), and using a fresh, recent environment.
+#
+#    The test environment is cached in /usr/share/miniconda3/envs/pangeo-forge-recipes
+
+jobs:
+  prepare-env:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10"]
+        dependencies: ["releases-only", "upstream-dev"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: 🔁 Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - name: 🔁 Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: pangeo-forge-recipes
+          use-mamba: true
+      - name: 🎯 Set cache number
+        id: cache-number
+        # cache will last 3 days by default
+        run: echo CACHE_NUMBER=`expr $(date +'%j') / 3` >> $GITHUB_ENV
+      - name: 🎯 Set environment file
+        id: env-file
+        run: echo "env_file=ci/py${{ matrix.python-version }}.yml" >> $GITHUB_ENV
+      - uses: actions/cache@v2
+        name: 🗃 Cache environment
+        with:
+          path: /usr/share/miniconda3/envs/pangeo-forge-recipes
+          key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles( env.env_file ) }}-${{ matrix.dependencies }}-${{ env.CACHE_NUMBER }}
+        id: conda-cache
+      - name: 🐫 Maybe Update environment
+        if: steps.conda-cache.outputs.cache-hit != 'true'
+        run: mamba env update -n pangeo-forge-recipes -f ${{ env.env_file }}
+      - name: 🧑‍💻 Maybe update to upstream dev versions
+        if: matrix.dependencies == 'upstream-dev'
+        run: mamba env update -n pangeo-forge-recipes -f ci/upstream-dev.yml
+      - name: 🐍 List conda env
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda list

--- a/.github/workflows/prepare-env.yaml
+++ b/.github/workflows/prepare-env.yaml
@@ -3,10 +3,18 @@ name: Prepare env
 on:
   workflow_call:
 
-# This is a pretty complicated workflow. The reason it is this way is that it
-# has been optimized to go fast fast. The specific optimizations are
+# ** What is this this workflow? **
 #
-# ## Environment building and caching ("prepare-env" job)
+#   This resuable environment building and caching ("prepare-env") workflow adds some complexity
+#   to our CI stack, in exchange for optimizing for speed. Other workflows which rely on it can
+#   load cached environments without needing to build them from scratch.
+#
+# ** How do I use it? **
+#
+#   To load a cached environment built by this workflow in another workflow, please refer to
+#   main.yaml in this directory, which demonstrates the proper use.
+#
+# ** Details **
 #
 #    This step builds and caches the test environments using conda.
 #    If there is no cache, building each environment takes 3-4 minutes.


### PR DESCRIPTION
This PR addresses the question previously posed here:

https://github.com/pangeo-forge/pangeo-forge-recipes/blob/45cc115f287ca7d33c33aaa343f21c862812c0bb/.github/workflows/tutorials.yaml#L98-L99

In #486, I have added some [integration tests](https://github.com/pangeo-forge/pangeo-forge-recipes/pull/486/files#diff-335719053561798e7e6a795ed48736a43cb2e42fba1aa365a8a9f355d4840f2f), which serve a role similar to the tutorial notebooks. And similarly, they will require the same (or similar) environment to the main unit tests, and it would be good to reuse the cached environments without duplicating a lot of code into the workflow that deploys them. From reviewing https://docs.github.com/en/actions/using-workflows/reusing-workflows, it seems like this should be pretty straightforward. 🤞 
