### PR TITLE
Include merge dim positions in group keys emitted by `split_fragments`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ _version.py
 # tutorials
 *.nc
 dask-worker-space
+
+# vscode
+.vscode/

--- a/pangeo_forge_recipes/rechunking.py
+++ b/pangeo_forge_recipes/rechunking.py
@@ -22,10 +22,11 @@ def split_fragment(
     schema: Optional[XarraySchema] = None,
 ) -> Iterator[Tuple[GroupKey, Tuple[Index, xr.Dataset]]]:
     """Split a single indexed dataset fragment into sub-fragments, according to the
-    specified target chunks
+    specified target chunks. Either target_chunks or schema (or both) must be provided.
 
-    :param fragment: the indexed fragment.
-    :param target_chunks_and_dims: mapping from dimension name to a tuple of (chunksize, dimsize)
+    :param fragment: The indexed fragment.
+    :param target_chunks: Mapping of dimension name to chunksize.
+    :param schema: An XarraySchema instance.
     """
 
     if target_chunks is None and schema is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ import aiohttp
 import apache_beam as beam
 import fsspec
 import pytest
+import xarray as xr
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.testing.test_pipeline import TestPipeline
 from dask.distributed import Client, LocalCluster
@@ -61,7 +62,10 @@ def split_up_files_by_day(ds, day_param):
     return datasets, fnames
 
 
-def split_up_files_by_variable_and_day(ds, day_param):
+def split_up_files_by_variable_and_day(
+    ds: xr.Dataset,
+    day_param: str,
+) -> tuple[list[xr.Dataset], list[str], dict]:
     all_dsets = []
     all_fnames = []
     fnames_by_variable = {}

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -33,12 +33,12 @@ def pipeline():
 @pytest.mark.parametrize("target_chunks", [{"time": 1}, {"time": 2}, {"time": 3}])
 def test_xarray_zarr(
     daily_xarray_dataset,
-    netcdf_local_file_pattern_sequential,
+    netcdf_local_file_pattern,
     pipeline,
     tmp_target_url,
     target_chunks,
 ):
-    pattern = netcdf_local_file_pattern_sequential
+    pattern = netcdf_local_file_pattern
     with pipeline as p:
         (
             p

--- a/tests/test_rechunking.py
+++ b/tests/test_rechunking.py
@@ -258,5 +258,3 @@ def test_combine_fragments_errors():
     index1 = Index({Dimension("time", CombineOp.CONCAT): IndexedPosition(2)})
     with pytest.raises(ValueError, match="are not consistent"):
         _ = combine_fragments(group, [(index0, ds), (index1, ds)])
-
-    #

--- a/tests/test_rechunking.py
+++ b/tests/test_rechunking.py
@@ -11,8 +11,7 @@ from .data_generation import make_ds
 
 
 @pytest.mark.parametrize("nt", [2])
-@pytest.mark.parametrize("nvars", [2])
-def test_split_and_combine_fragments_with_merge_dim(nt, nvars):
+def test_split_and_combine_fragments_with_merge_dim(nt):
     """Test if sub-fragments split from datasets with merge dims can be combined with each other."""
 
     t_offset = 0

--- a/tests/test_rechunking.py
+++ b/tests/test_rechunking.py
@@ -61,8 +61,8 @@ def test_split_and_combine_fragments_with_merge_dim(nt_dayparam, time_chunks):
     for g in sorted(groupkeys):
         # just confirms that grouping logic within this test is correct
         assert all([sf.groupkey == g for sf in grouped_subfragments[g]])
-        # for each subfragment in the current group, assert that there is only merge dimension
-        # positional value present. this verifies that `split_fragments` has not incorrectly
+        # for the merge dimension of each subfragment in the current group, assert that there
+        # is only one positional value present. this verifies that `split_fragments` has not
         # grouped distinct merge dimension positional values together under the same groupkey.
         merge_position_vals = [sf.content[0][merge_dim].value for sf in grouped_subfragments[g]]
         assert all([v == merge_position_vals[0] for v in merge_position_vals])

--- a/tests/test_rechunking.py
+++ b/tests/test_rechunking.py
@@ -88,7 +88,7 @@ def test_split_fragment_possible_bug():
     ds = make_ds(nt=nt)  # this represents a single dataset fragment
     dimension = Dimension("time", CombineOp.CONCAT)
 
-    offset = 1
+    offset = 2
     index = Index([(dimension, IndexedPosition(offset, dimsize=nt_total))])
     all_splits = list(split_fragment((index, ds), target_chunks=target_chunks))
 

--- a/tests/test_rechunking.py
+++ b/tests/test_rechunking.py
@@ -2,7 +2,6 @@ import itertools
 import random
 from collections import namedtuple
 
-import numpy as np
 import pytest
 import xarray as xr
 
@@ -27,8 +26,7 @@ def test_split_and_combine_fragments_with_merge_dim(nt_dayparam, time_chunks):
     dsets, _, _ = split_up_files_by_variable_and_day(ds, dayparam)
 
     # replicates indexes created by IndexItems transform.
-    unique_times = np.unique([ds.time[0].values for ds in dsets])
-    time_positions = {t: i for i, t in enumerate(unique_times)}
+    time_positions = {t: i for i, t in enumerate(ds.time.values)}
     merge_dim = Dimension("variable", CombineOp.MERGE)
     concat_dim = Dimension("time", CombineOp.CONCAT)
     indexes = [

--- a/tests/test_rechunking.py
+++ b/tests/test_rechunking.py
@@ -60,7 +60,7 @@ def test_split_and_combine_fragments_with_merge_dim(nt_resample, time_chunks):
     for sf in subfragments:
         grouped_subfragments[sf.groupkey].append(sf)
 
-    for g in groupkeys:
+    for g in sorted(groupkeys):
         # just confirms that grouping logic within this test is correct
         assert all([sf.groupkey == g for sf in grouped_subfragments[g]])
         # for each subfragment in the current group, assert that there is only merge dimension
@@ -69,10 +69,10 @@ def test_split_and_combine_fragments_with_merge_dim(nt_resample, time_chunks):
         merge_position_vals = [sf.subfragment[0][merge_dim].value for sf in grouped_subfragments[g]]
         assert all([v == merge_position_vals[0] for v in merge_position_vals])
         # now actually try to combine the fragments
-        # _, ds_combined = combine_fragments(
-        #     g,
-        #     [sf.subfragment for sf in grouped_subfragments[g]],
-        # )
+        _, ds_combined = combine_fragments(
+            g,
+            [sf.subfragment for sf in grouped_subfragments[g]],
+        )
 
 
 @pytest.mark.parametrize("offset", [0, 5])  # hypothetical offset of this fragment

--- a/tests/test_rechunking.py
+++ b/tests/test_rechunking.py
@@ -75,43 +75,6 @@ def test_split_and_combine_fragments_with_merge_dim(nt_dayparam, time_chunks):
         )
 
 
-def test_split_fragment_possible_bug():
-    """Reproduces possible bug observed in certain parametrizations of
-    `test_split_and_combine_fragments_with_merge_dim`.
-    """
-
-    nt_total = 10  # the total size of the hypothetical dataset
-    time_chunks = 1
-    target_chunks = {"time": time_chunks}
-
-    nt = 2
-    ds = make_ds(nt=nt)  # this represents a single dataset fragment
-    dimension = Dimension("time", CombineOp.CONCAT)
-
-    offset = 2
-    index = Index([(dimension, IndexedPosition(offset, dimsize=nt_total))])
-    all_splits = list(split_fragment((index, ds), target_chunks=target_chunks))
-
-    group_keys = [item[0] for item in all_splits]
-    new_datasets = [item[1][1] for item in all_splits]
-
-    # check that new datasets time dimensions were split as expected
-    for i, nds in enumerate(new_datasets):
-        assert len(nds.time) == time_chunks
-        # this will only pass for currently hardcoded value `time_chunks = 1`,
-        # but that's okay bc it's meant to be illustrative of this particular
-        # case, not generalizable
-        assert nds.time == ds.time[i]
-
-    # based on observations of `test_split_and_combine_fragments_with_merge_dim`,
-    # i believe the `expected_group_keys` defined below this comment are correct,
-    # but the `group_keys` emitted by `split_fragments` are: `[(("time", 1),), (("time", 2),)]`.
-    # these (incorrect?) group keys are consistent with those reported in:
-    # https://github.com/pangeo-forge/pangeo-forge-recipes/pull/521#issuecomment-1612227064.
-    expected_group_keys = [(("time", 2),), (("time", 3),)]
-    assert group_keys == expected_group_keys
-
-
 @pytest.mark.parametrize("offset", [0, 5])  # hypothetical offset of this fragment
 @pytest.mark.parametrize("time_chunks", [1, 3, 5, 10, 11])
 def test_split_fragment(time_chunks, offset):

--- a/tests/test_rechunking.py
+++ b/tests/test_rechunking.py
@@ -68,12 +68,11 @@ def test_split_and_combine_fragments_with_merge_dim(nt_resample, time_chunks):
         # grouped distinct merge dimension positional values together under the same groupkey.
         merge_position_vals = [sf.subfragment[0][merge_dim].value for sf in grouped_subfragments[g]]
         assert all([v == merge_position_vals[0] for v in merge_position_vals])
+        # now actually try to combine the fragments
         # _, ds_combined = combine_fragments(
-        #     groupkey,
-        #     [sf.subfragment for sf in grouped_subfragments[groupkey]],
+        #     g,
+        #     [sf.subfragment for sf in grouped_subfragments[g]],
         # )
-        # assert "foo" in ds_combined.data_vars
-        # assert "bar" in ds_combined.data_vars
 
 
 @pytest.mark.parametrize("offset", [0, 5])  # hypothetical offset of this fragment

--- a/tests/test_rechunking.py
+++ b/tests/test_rechunking.py
@@ -71,6 +71,15 @@ def test_split_and_combine_fragments_with_merge_dim(nt_dayparam, time_chunks):
             g,
             [sf.content for sf in grouped_subfragments[g]],
         )
+        # ensure vars are *not* combined (we only want to concat, not merge)
+        assert len([k for k in ds_combined.data_vars.keys()]) == 1
+        # check that time chunking is correct
+        if nt % time_chunks == 0:
+            assert len(ds_combined.time) == time_chunks
+        else:
+            # if `nt` is not evenly divisible by `time_chunks`, all chunks will be of
+            # `len(time_chunks)` except the last one, which will be the lenth of the remainder
+            assert len(ds_combined.time) in [time_chunks, nt % time_chunks]
 
 
 @pytest.mark.parametrize("offset", [0, 5])  # hypothetical offset of this fragment


### PR DESCRIPTION
Opening up a PR to start working on a bugfix for the error described in Issue #517 .

The error from #517 happens in L185  of `rechunking.py` in the `combine_fragments` function.

As @rabernat pointed out in #517, the error might be upstream in the `split_fragments` function.

> Basically, it splits up the original dataset pieces into fragments, 
> and then puts them back together. Each merge dim should end up in a separate group. 


So if I'm understanding this correctly, `split_fragments` does not take the `MergeDim` into account and outputs PCollections/Fragments that contain multiple variables. When fed into `combine_fragments`, we get the error: `Expected a hypercube of shape [1] but got 2 fragments`

There is the begining of a test named `test_split_fragment_merge_dim` in `test_rechunking.py`

cc @cisaacstern 