### PR TITLE
Adds a `tiff` filetype for rasterio engine option

### DIFF
--- a/pangeo_forge_recipes/openers.py
+++ b/pangeo_forge_recipes/openers.py
@@ -41,6 +41,7 @@ OPENER_MAP = {
     FileType.netcdf4: dict(engine="h5netcdf"),
     FileType.zarr: dict(engine="zarr"),
     FileType.opendap: dict(engine="netcdf4"),
+    FileType.tiff: dict(engine="rasterio"),
 }
 
 

--- a/pangeo_forge_recipes/patterns.py
+++ b/pangeo_forge_recipes/patterns.py
@@ -84,11 +84,12 @@ class AutoName(Enum):
 
 
 class FileType(AutoName):
-    unknown = auto()
+    grib = auto()
     netcdf3 = auto()
     netcdf4 = auto()
-    grib = auto()
     opendap = auto()
+    tiff = auto()
+    unknown = auto()
     zarr = auto()
 
 


### PR DESCRIPTION
Tiny PR that adds the option to use the `rasterio` backend if a `tiff` filetype is specified. 