### PR TITLE
Update default branch to main in workflows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,11 +2,11 @@ name: Tests
 
 on:
   push:
-    branches: "*"
+    branches: [ "main" ]
     paths-ignore:
     - 'docs/**'
   pull_request:
-    branches: [master, beam-refactor]
+    branches: [ "main" ]
     paths-ignore:
     - 'docs/**'
 
@@ -24,10 +24,6 @@ env:
 #   - Generating the cache key
 #   - Actually loading the environment using the key
 #   - Adding the path ``/usr/share/miniconda3/envs/pangeo-forge-recipes/bin`` to $PATH
-#
-# Apart from the caching logic, we use pytest marks to parallelize execution across different
-# executors. These marks are configured in tests/conftest.py, and represent a testing regime
-# which pre-dates the beam-refactor. We may want to deprecate them.
 
 jobs:
   prepare-env:

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -2,9 +2,9 @@ name: Integration tests
 
 on:
   push:
-    branches: [ "beam-refactor" ]  # FIXME: change to default branch post-merge
+    branches: [ "main" ]
   pull_request:
-    branches: [ "beam-refactor" ]  # FIXME: change to default branch post-merge
+    branches: [ "main" ]
     types: [ opened, reopened, synchronize, labeled ]
 
 env:

--- a/.github/workflows/tutorials.yaml
+++ b/.github/workflows/tutorials.yaml
@@ -2,7 +2,7 @@ name: Test Tutorial Notebooks
 
 on:
   push:
-    branches: master
+    branches: main
   repository_dispatch:
     types: [run-test-tutorials-command]
   workflow_dispatch:


### PR DESCRIPTION
As the title indicates, this updates workflows to reflect that our default branch is now `main` (created from `beam-refactor`).