### PR TITLE
Attempt fixing typing issues raised with `runtime_type_check=True`

### DIFF
--- a/pangeo_forge_recipes/openers.py
+++ b/pangeo_forge_recipes/openers.py
@@ -3,7 +3,7 @@
 import io
 import tempfile
 import warnings
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 import xarray as xr
@@ -134,7 +134,7 @@ def open_with_kerchunk(
     storage_options: Optional[Dict] = None,
     remote_protocol: Optional[str] = None,
     kerchunk_open_kwargs: Optional[dict] = None,
-) -> list[dict]:
+) -> List[Dict]:
     """Scan through item(s) with one of Kerchunk's file readers (SingleHdf5ToZarr, scan_grib etc.)
     and create reference objects.
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -25,7 +25,7 @@ from pangeo_forge_recipes.transforms import (
 
 @pytest.fixture
 def pipeline():
-    options = PipelineOptions(runtime_type_check=False)
+    options = PipelineOptions(runtime_type_check=True)
     with TestPipeline(options=options) as p:
         yield p
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -25,7 +25,7 @@ from pangeo_forge_recipes.transforms import (
 
 @pytest.fixture
 def pipeline():
-    options = PipelineOptions(runtime_type_check=True)
+    options = PipelineOptions(runtime_type_check=True, type_check_additional="all")
     with TestPipeline(options=options) as p:
         # with `runtime_type_check=True`, `yield`ing here results in strange type checker errors
         # during test teardown, even though the test itself has passed. `return`ing from here fixes

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -27,7 +27,10 @@ from pangeo_forge_recipes.transforms import (
 def pipeline():
     options = PipelineOptions(runtime_type_check=True)
     with TestPipeline(options=options) as p:
-        yield p
+        # with `runtime_type_check=True`, `yield`ing here results in strange type checker errors
+        # during test teardown, even though the test itself has passed. `return`ing from here fixes
+        # that. we don't actually do any teardown from this fixture, so this is presumably okay.
+        return p
 
 
 @pytest.mark.parametrize("target_chunks", [{"time": 1}, {"time": 2}, {"time": 3}])


### PR DESCRIPTION
Thanks to @alxmrs, I now understand that the issue reported in https://github.com/leap-stc/data-management/pull/33#issuecomment-1648522152 (and discussed further in that thread), is almost definitely being caused by imprecise type hints ➡️ inaccurate beam coders ➡️ loss of type safety on decoding serialized PCollection values on Dataflow. The beam docs link Alex provided in https://github.com/leap-stc/data-management/pull/33#issuecomment-1650983722 is especially enlightening on this subject:

> https://beam.apache.org/documentation/sdks/python-type-safety/

Regarding the error in the linked issue, the comment here

https://github.com/pangeo-forge/pangeo-forge-recipes/blob/f0c7dac8a9a49533fe544dc2fd84e501f9d96508/pangeo_forge_recipes/rechunking.py#L148-L150

is the best clue I've found so far, given that the error relates specifically to improperly decoded PCollection values passed to `combine_fragments`.

In this branch, I'm attempting to solve this particular issue, while also paying down a bit of typing debt more broadly, by setting `runtime_type_check=True` in the end-to-end tests, and seeing if I can resolve the issues Beam's type checker raises with that flag set.