### PR TITLE
Added cfgrib as an opner for grib Files

### DIFF
--- a/pangeo_forge_recipes/openers.py
+++ b/pangeo_forge_recipes/openers.py
@@ -41,6 +41,7 @@ OPENER_MAP = {
     FileType.netcdf4: dict(engine="h5netcdf"),
     FileType.zarr: dict(engine="zarr"),
     FileType.opendap: dict(engine="netcdf4"),
+    FileType.grib: dict(engine='cfgrib')
 }
 
 

--- a/pangeo_forge_recipes/openers.py
+++ b/pangeo_forge_recipes/openers.py
@@ -41,7 +41,7 @@ OPENER_MAP = {
     FileType.netcdf4: dict(engine="h5netcdf"),
     FileType.zarr: dict(engine="zarr"),
     FileType.opendap: dict(engine="netcdf4"),
-    FileType.grib: dict(engine='cfgrib')
+    FileType.grib: dict(engine="cfgrib"),
 }
 
 


### PR DESCRIPTION
Added an opener `cfgrib` for `grib` files as it's missing and causes an error on [Line 84](https://github.com/pangeo-forge/pangeo-forge-recipes/blob/main/pangeo_forge_recipes/openers.py#L84) for `opener.py` module.