### PR TITLE
Concurrency limiting

### DIFF
--- a/pangeo_forge_recipes/openers.py
+++ b/pangeo_forge_recipes/openers.py
@@ -3,7 +3,7 @@
 import io
 import tempfile
 import warnings
-from typing import Dict, Iterable, Iterator, Optional, Union
+from typing import Dict, Optional, Union
 from urllib.parse import urlparse
 
 import xarray as xr
@@ -34,20 +34,6 @@ def open_url(
     else:
         open_file = _get_opener(url, secrets, **kw)
     return open_file
-
-
-def open_urls(
-    keyed_urls: Iterable,
-    cache: Optional[CacheFSSpecTarget] = None,
-    secrets: Optional[Dict] = None,
-    open_kwargs: Optional[Dict] = None,
-) -> Iterator[OpenFileType]:
-    """Calls `open_url` in a serial loop across an input collection of urls."""
-
-    for elem in keyed_urls:
-        key, url = elem
-        opened_url = open_url(url, cache, secrets, open_kwargs)
-        yield key, opened_url
 
 
 OPENER_MAP = {

--- a/pangeo_forge_recipes/openers.py
+++ b/pangeo_forge_recipes/openers.py
@@ -3,7 +3,7 @@
 import io
 import tempfile
 import warnings
-from typing import Dict, Iterator, Optional, Union
+from typing import Dict, Iterable, Iterator, Optional, Union
 from urllib.parse import urlparse
 
 import xarray as xr
@@ -37,15 +37,17 @@ def open_url(
 
 
 def open_urls(
-    urls: tuple[str],
+    keyed_urls: Iterable,
     cache: Optional[CacheFSSpecTarget] = None,
     secrets: Optional[Dict] = None,
     open_kwargs: Optional[Dict] = None,
 ) -> Iterator[OpenFileType]:
     """Calls `open_url` in a serial loop across an input collection of urls."""
 
-    for url in urls:
-        yield open_url(url, cache, secrets, open_kwargs)
+    for elem in keyed_urls:
+        key, url = elem
+        opened_url = open_url(url, cache, secrets, open_kwargs)
+        yield key, opened_url
 
 
 OPENER_MAP = {

--- a/pangeo_forge_recipes/openers.py
+++ b/pangeo_forge_recipes/openers.py
@@ -3,7 +3,7 @@
 import io
 import tempfile
 import warnings
-from typing import Dict, Optional, Union
+from typing import Dict, Iterator, Optional, Union
 from urllib.parse import urlparse
 
 import xarray as xr
@@ -34,6 +34,18 @@ def open_url(
     else:
         open_file = _get_opener(url, secrets, **kw)
     return open_file
+
+
+def open_urls(
+    urls: tuple[str],
+    cache: Optional[CacheFSSpecTarget] = None,
+    secrets: Optional[Dict] = None,
+    open_kwargs: Optional[Dict] = None,
+) -> Iterator[OpenFileType]:
+    """Calls `open_url` in a serial loop across an input collection of urls."""
+
+    for url in urls:
+        yield open_url(url, cache, secrets, open_kwargs)
 
 
 OPENER_MAP = {

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -57,7 +57,7 @@ Indexed = Tuple[Index, T]
 
 
 # TODO: replace with beam.MapTuple?
-def _add_keys(func: Callable):
+def _add_keys(func: Callable) -> Callable:
     """Convenience decorator to remove and re-add keys to items in a Map"""
     annotations = func.__annotations__.copy()
     arg_name, annotation = next(iter(annotations.items()))
@@ -75,7 +75,7 @@ def _add_keys(func: Callable):
     return wrapper
 
 
-def _add_keys_iter(func: Callable):
+def _add_keys_iter(func: Callable) -> Callable:
     """Convenience decorator to iteratively remove and re-add keys to items in a FlatMap"""
     annotations = func.__annotations__.copy()
     arg_name, annotation = next(iter(annotations.items()))

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -5,13 +5,13 @@ import random
 from dataclasses import dataclass, field
 
 # from functools import wraps
-from typing import Dict, List, Optional, Tuple, TypeVar
+from typing import Dict, Iterable, Iterator, List, Optional, Tuple, TypeVar
 
 import apache_beam as beam
 
 from .aggregation import XarraySchema, dataset_to_schema, schema_to_zarr
 from .combiners import CombineMultiZarrToZarr, CombineXarraySchemas
-from .openers import open_url, open_urls, open_with_kerchunk, open_with_xarray
+from .openers import OpenFileType, open_url, open_with_kerchunk, open_with_xarray
 from .patterns import CombineOp, Dimension, FileType, Index, augment_index_with_start_stop
 from .rechunking import combine_fragments, split_fragment
 from .storage import CacheFSSpecTarget, FSSpecTarget
@@ -75,6 +75,10 @@ def _add_keys(func):
     return wrapper
 
 
+# FIXME: can `_add_keys_iter` this be made into a generic wrapper to replace `_open_urls`?
+# i.e.: `FlatMap(_add_keys_iter(open_url))` instead of `FlatMap(_open_urls)`?
+# if so, do that. if not, remove before merge
+
 # def _add_keys_iter(func: Callable):
 #     """Convenience decorator to iteratively remove and re-add keys to items in a FlatMap"""
 #     annotations = func.__annotations__.copy()
@@ -108,6 +112,24 @@ class DropKeys(beam.PTransform):
         return pcoll | "Drop Keys" >> beam.Map(_drop_keys)
 
 
+def _open_urls(
+    keyed_urls: Iterable,
+    cache: Optional[CacheFSSpecTarget] = None,
+    secrets: Optional[Dict] = None,
+    open_kwargs: Optional[Dict] = None,
+) -> Iterator[OpenFileType]:
+    """Calls `open_url` in a serial loop across an input collection of keyed urls."""
+
+    for elem in keyed_urls:
+        key, url = elem
+        opened_url = open_url(url, cache, secrets, open_kwargs)
+        yield key, opened_url
+
+
+def _assign_concurrency_group(elem, max_concurrency: int):
+    return (random.randint(0, max_concurrency - 1), elem)
+
+
 # This has side effects if using a cache
 @dataclass
 class OpenURLWithFSSpec(beam.PTransform):
@@ -123,10 +145,6 @@ class OpenURLWithFSSpec(beam.PTransform):
     secrets: Optional[dict] = None
     open_kwargs: Optional[dict] = None
     max_concurrency: Optional[int] = None
-
-    @staticmethod
-    def _assign_concurrency_group(elem, max_concurrency: int):
-        return (random.randint(0, max_concurrency - 1), elem)
 
     def expand(self, pcoll):
         if isinstance(self.cache, str):
@@ -146,10 +164,10 @@ class OpenURLWithFSSpec(beam.PTransform):
                 pcoll
                 # TODO: factor next three stages into a standalone PTransform
                 # so they can be reused elsewhere (e.g. OpenWithKerchunk)
-                | beam.Map(self._assign_concurrency_group, self.max_concurrency)
+                | beam.Map(_assign_concurrency_group, self.max_concurrency)
                 | beam.GroupByKey()
                 | DropKeys()
-                | f"Open with fsspec ({self.max_concurrency=})" >> beam.FlatMap(open_urls, **kws)
+                | f"Open with fsspec ({self.max_concurrency=})" >> beam.FlatMap(_open_urls, **kws)
             )
         )
 

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -5,7 +5,7 @@ import random
 from dataclasses import dataclass, field
 
 # from functools import wraps
-from typing import Callable, Dict, Iterator, List, Optional, Tuple, TypeVar
+from typing import Callable, Dict, Iterable, Iterator, List, Optional, Tuple, TypeVar
 
 import apache_beam as beam
 
@@ -79,12 +79,10 @@ def _add_keys_iter(func: Callable):
     """Convenience decorator to iteratively remove and re-add keys to items in a FlatMap"""
     annotations = func.__annotations__.copy()
     arg_name, annotation = next(iter(annotations.items()))
-    annotations[arg_name] = Tuple[Index, annotation]
     return_annotation = annotations["return"]
-    # without `type: ignore` on next line, mypy complains with
-    #   error: Variable "return_annotation" is not valid as a type  [valid-type]
-    #   See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
-    # is there any way to satisfy mypy here, or do we need to just keep the ignore?
+
+    # mypy doesn't view `annotation` and `return_annotation` as valid types, so ignore
+    annotations[arg_name] = Iterable[Tuple[Index, annotation]]  # type: ignore
     annotations["return"] = Iterator[Tuple[Index, return_annotation]]  # type: ignore
 
     def iterable_wrapper(arg, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,13 +233,25 @@ def pipeline(scope="session"):
         yield p
 
 
+@pytest.fixture(
+    params=[True, False],
+    ids=["concurrency_limit", "no_concurrency_limit"],
+)
+def max_concurrency(request):
+    if request.param:
+        return 2
+    else:
+        return None
+
+
 @pytest.fixture
-def pcoll_opened_files(pattern, cache_url):
+def pcoll_opened_files(pattern, cache_url, max_concurrency):
     input = beam.Create(pattern.items())
     output = input | OpenURLWithFSSpec(
         cache=cache_url,
         secrets=pattern.query_string_secrets,
         open_kwargs=pattern.fsspec_open_kwargs,
+        max_concurrency=max_concurrency,
     )
     return output, pattern, cache_url
 


### PR DESCRIPTION
WIP, will close #45 and #389 when complete.

Prioritizing this because it is blocking https://github.com/leap-stc/data-management/issues/36, and also because it's been a long standing feature request to unblock many different recipes. Implementation using `GroupByKey` adapted from example provided by @alxmrs's in linked issue, with this being the key couple lines:

> https://github.com/google/weather-tools/blob/bb2274d2be4ed51a9a6cc3bc79a8be110b250509/weather_mv/loader_pipeline/util.py#L380-L381