### PR TITLE
Support python 3.11 too

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         dependencies: ["releases-only", "upstream-dev"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/prepare-env.yaml
+++ b/.github/workflows/prepare-env.yaml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         dependencies: ["releases-only", "upstream-dev"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         dependencies: ["releases-only", "upstream-dev"]
     steps:
       - uses: actions/checkout@v2

--- a/ci/py3.11.yml
+++ b/ci/py3.11.yml
@@ -2,7 +2,7 @@ name: pangeo-forge-recipes
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
+  - python=3.11
   - aiohttp
   - apache-beam
   - black


### PR DESCRIPTION
Newer versions of apache beam now support python 3.11 too, no reason we can't.