### PR TITLE
Added Labels In DetermineSchema

### DIFF
--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -305,8 +305,8 @@ class DetermineSchema(beam.PTransform):
             else:
                 schemas = (
                     schemas
-                    | _NestDim(last_dim)
-                    | beam.CombinePerKey(CombineXarraySchemas(last_dim))
+                    | f"Nest {last_dim.name}" >> _NestDim(last_dim)
+                    | f"Combine {last_dim.name}" >> beam.CombinePerKey(CombineXarraySchemas(last_dim))
                 )
         return schemas
 


### PR DESCRIPTION
- While using more than 2 `concat` Dimension `apache-beam` is throwing below Error.
```
RuntimeError: A transform with label "DetermineSchema/_NestDim" already exists in the pipeline. To apply a transform with a specified label write pvalue | "label" >> transform
```
- Adding labels for every recursive call of `PTransform` in this PR.
- Find more discussion here https://github.com/pangeo-forge/pangeo-forge-recipes/issues/402.