### PR TITLE
Try sphinx 6.2.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==3.5.4
+sphinx==6.2.1
 pangeo-sphinx-book-theme==0.2
 myst-parser==0.13.6
 myst-nb==0.12.3


### PR DESCRIPTION
Dependabot keeps suggesting we upgrade sphinx (e.g. #592), and docs builds lately fail on those PRs, so I've been closing them.

I know we can have Dependabot ignore sphinx upgrades, but before we do that, I wanted to see if we can bump to this version, because we admittedly are on a quite old sphinx version currently.

I've chosen 6.2.1 because its the latest version in the 6.*.* series, and our base theme, `sphinx-book-theme`, [supports `<7`](https://github.com/executablebooks/sphinx-book-theme/blob/a9794b73cec766e01bee35a96f7d44e22851f278/pyproject.toml#L25).

Presumably the first build will fail here due to incompatibility with other pinned docs requirements. I'll clean that up in a follow-on commit here.