### PR TITLE
Disable pre-commit autofix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+    autofix_prs: false
+
 repos:
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
First observed to me by @norlandrhagen in #556, then by me in #590... pre-commit.ci seems to be attempted to propose autofix changes for files not changed by the PR. This is very distracting. If anyone can figure out why this is and how to get pre-commit.ci to only make changes to files changed by the PR, we can re-enable.