### PR TITLE
Reenable precommit autofix without prettifying docs json

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-ci:
-    autofix_prs: false
-
 repos:
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
@@ -13,6 +10,7 @@ repos:
     - id: check-yaml
     - id: pretty-format-json
       args: ["--autofix", "--indent=2", "--no-sort-keys"]
+      exclude_types: [ipynb]
 
 -   repo: https://github.com/psf/black
     rev: 22.12.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     - id: check-yaml
     - id: pretty-format-json
       args: ["--autofix", "--indent=2", "--no-sort-keys"]
-      exclude_types: [ipynb]
+      exclude: "docs/"
 
 -   repo: https://github.com/psf/black
     rev: 22.12.0


### PR DESCRIPTION
Looks like this may do what we need to reenable pre-commit autofix following #601, but without all of those unwanted changes we were seeing.