### PR TITLE
Workaround broken conda release of beam 2.50.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -70,7 +70,8 @@ jobs:
       - name: 🔧 Workaround broken beam conda release with pip install
         shell: bash -l {0}
         run: |
-          python -m pip install -U apache-beam
+          python -m pip uninstall apache-beam -y
+          python -m pip install apache-beam
 
       - name: 🏄‍♂️ Run Tests
         shell: bash -l {0}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -64,6 +64,14 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install --no-deps -e  .
+
+      # workaround for https://github.com/conda-forge/apache-beam-feedstock/issues/67
+      # this can be removed once that bug is fixed
+      - name: 🔧 Workaround broken beam conda release with pip install
+        shell: bash -l {0}
+        run: |
+          python -m pip install -U apache-beam
+
       - name: 🏄‍♂️ Run Tests
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
In the last few days we started to see some confusing test failures. After shedding some serious keyboard tears 🧑‍💻 😢 , I was eventually able to figure out that (for reasons as-yet unclear to me) the `assert_that` testing utility is broken in the beam 2.50.0 release _on conda only_:

- https://github.com/conda-forge/apache-beam-feedstock/issues/67
- https://github.com/cisaacstern/beam2.50.0-assert-that-bug/pull/1

Until the linked bug is fixed, this workaround should allow us to move forward.