### PR TITLE
Schedule upstream dev tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,6 +9,8 @@ on:
     branches: [ "main" ]
     paths-ignore:
     - 'docs/**'
+  schedule:
+    - cron: '0 4 * * *'  # run once a day at 4 AM
 
 env:
   PYTEST_ADDOPTS: "--color=yes"
@@ -20,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
-        dependencies: ["releases-only", "upstream-dev"]
     steps:
       - uses: actions/checkout@v3
       - name: 🔁 Setup Python
@@ -36,8 +37,9 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install -e  ".[dev]"
-      - name: 🧑‍💻 Maybe update to upstream dev versions
-        if: matrix.dependencies == 'upstream-dev'
+      - name: 🧑‍💻 On the nightly run, test upstream dev versions
+        if: |
+          github.event_name == 'schedule'
         run: |
           python -m pip install -Ur ci/requirements-upstream-dev.txt
       - name: 🏄‍♂️ Run Tests
@@ -49,6 +51,9 @@ jobs:
             --cov-report xml \
             --durations=10 --durations-min=1.0
       - name: 🚦 Run Codecov
+        if: |
+          github.event_name == 'push' ||
+          github.event_name == 'pull_request'
         uses: codecov/codecov-action@v3.1.4
         with:
           file: ./coverage.xml

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,8 +40,10 @@ jobs:
       - name: 🧑‍💻 On the nightly run, test upstream dev versions
         if: |
           github.event_name == 'schedule'
+        shell: bash -l {0}
         run: |
           python -m pip install -Ur ci/requirements-upstream-dev.txt
+          python -m pip install -U --pre apache-beam
       - name: 🏄‍♂️ Run Tests
         shell: bash -l {0}
         run: |

--- a/ci/requirements-upstream-dev.txt
+++ b/ci/requirements-upstream-dev.txt
@@ -1,3 +1,4 @@
 git+https://github.com/fsspec/filesystem_spec.git
 git+https://github.com/pydata/xarray.git
 git+https://github.com/fsspec/kerchunk.git
+git+https://github.com/zarr-developers/zarr-python.git


### PR DESCRIPTION
Towards #606

IMO we don't need to be testing against upstream dev versions on every commit of every PR.

This PR instead tests against upstream dev versions once nightly, which should still allow us to surface any potential issues in a timely fashion, while also reducing clutter on PR commit checks.