### PR TITLE
In `examples/`, add CLI commands as shell scripts, and test them

### DIFF
--- a/examples/runner-commands/bake.sh
+++ b/examples/runner-commands/bake.sh
@@ -1,0 +1,1 @@
+pangeo-forge-runner bake --repo=$REPO -f=$CONFIG_FILE --Bake.recipe_id=$RECIPE_ID --Bake.job_name=$JOB_NAME --prune


### PR DESCRIPTION
Previously CLI commands in the integration tests were hardcoded into the pytest module.

Moving them to a shell script in `examples/` will make it easier to render them directly in the docs.