### PR TITLE
Add `py.typed` marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ write_to_template = "__version__ = '{version}'"
 [tool.setuptools.packages.find]
 exclude = ["docs_src"]
 
+[tool.setuptools.package-data]
+pangeo_forge_recipes = ["py.typed"]
+
 [tool.black]
 line-length = 100
 


### PR DESCRIPTION
Add `py.typed` marker to play nicely with static type checkers.

Fixes #612