### PR TITLE
Allow injectable attrs in StoreToZarr

### DIFF
--- a/pangeo_forge_recipes/aggregation.py
+++ b/pangeo_forge_recipes/aggregation.py
@@ -249,7 +249,7 @@ def determine_target_chunks(
 def schema_to_template_ds(
     schema: XarraySchema,
     specified_chunks: Optional[Dict[str, int]] = None,
-    attrs: Optional[Dict[str]] = None,
+    attrs: Optional[Dict[str, str]] = None,
 ) -> xr.Dataset:
     """Convert a schema to an xarray dataset as lazily as possible."""
 
@@ -277,7 +277,7 @@ def schema_to_zarr(
     schema: XarraySchema,
     target_store: zarr.storage.FSStore,
     target_chunks: Optional[Dict[str, int]] = None,
-    attrs: Optional[Dict[str]] = None,
+    attrs: Optional[Dict[str, str]] = None,
 ) -> zarr.storage.FSStore:
     """Initialize a zarr group based on a schema."""
     ds = schema_to_template_ds(schema, specified_chunks=target_chunks, attrs=attrs)

--- a/pangeo_forge_recipes/aggregation.py
+++ b/pangeo_forge_recipes/aggregation.py
@@ -265,7 +265,7 @@ def schema_to_template_ds(
     }
     dataset_attrs = schema["attrs"]
 
-    if bool(attrs) & isinstance(attrs, dict):
+    if attrs and isinstance(attrs, dict):
         for k, v in attrs.items():  # type: ignore
             dataset_attrs[f"pangeo-forge:{k}"] = v
 

--- a/pangeo_forge_recipes/aggregation.py
+++ b/pangeo_forge_recipes/aggregation.py
@@ -265,8 +265,8 @@ def schema_to_template_ds(
     }
     dataset_attrs = schema["attrs"]
 
-    if bool(attrs):
-        for k, v in attrs.items():
+    if bool(attrs) & isinstance(attrs, dict):
+        for k, v in attrs.items():  # type: ignore
             dataset_attrs[f"pangeo-forge:{k}"] = v
 
     ds = xr.Dataset(data_vars=data_vars, coords=coords, attrs=dataset_attrs)

--- a/pangeo_forge_recipes/aggregation.py
+++ b/pangeo_forge_recipes/aggregation.py
@@ -247,7 +247,7 @@ def determine_target_chunks(
 
 
 def schema_to_template_ds(
-    schema: XarraySchema, specified_chunks: Optional[Dict[str, int]] = None
+    schema: XarraySchema, specified_chunks: Optional[Dict[str, int]] = None, attrs: Optional[Dict[str]] = None
 ) -> xr.Dataset:
     """Convert a schema to an xarray dataset as lazily as possible."""
 
@@ -261,8 +261,13 @@ def schema_to_template_ds(
     coords = {
         name: _to_variable(template, target_chunks) for name, template in schema["coords"].items()
     }
+    dataset_attrs = schema["attrs"]
 
-    ds = xr.Dataset(data_vars=data_vars, coords=coords, attrs=schema["attrs"])
+    if bool(attrs):
+        for k, v in attrs.items(): 
+            dataset_attrs[f"pangeo-forge:{k}"] = v 
+
+    ds = xr.Dataset(data_vars=data_vars, coords=coords, attrs=dataset_attrs)
     return ds
 
 
@@ -270,9 +275,10 @@ def schema_to_zarr(
     schema: XarraySchema,
     target_store: zarr.storage.FSStore,
     target_chunks: Optional[Dict[str, int]] = None,
+    attrs: Optional[Dict[str]] = None,
 ) -> zarr.storage.FSStore:
     """Initialize a zarr group based on a schema."""
-    ds = schema_to_template_ds(schema, specified_chunks=target_chunks)
+    ds = schema_to_template_ds(schema, specified_chunks=target_chunks, attrs=attrs)
     # using mode="w" makes this function idempotent
     ds.to_zarr(target_store, mode="w", compute=False)
     return target_store

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -362,7 +362,7 @@ class PrepareZarrTarget(beam.PTransform):
 
     target: str | FSSpecTarget
     target_chunks: Dict[str, int] = field(default_factory=dict)
-    attrs: Dict[str] = field(default_factory=dict)
+    attrs: Dict[str, str] = field(default_factory=dict)
 
     def expand(self, pcoll: beam.PCollection) -> beam.PCollection:
         if isinstance(self.target, str):
@@ -492,7 +492,7 @@ class StoreToZarr(beam.PTransform, ZarrWriterMixin):
         default_factory=RequiredAtRuntimeDefault
     )
     target_chunks: Dict[str, int] = field(default_factory=dict)
-    attrs: Dict[str] = field(default_factory=dict)
+    attrs: Dict[str, str] = field(default_factory=dict)
 
     def expand(
         self,

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -357,10 +357,12 @@ class PrepareZarrTarget(beam.PTransform):
         If a dimension is a not named, the chunks will be inferred from the schema.
         If chunking is present in the schema for a given dimension, the length of
         the first fragment will be used. Otherwise, the dimension will not be chunked.
+    :param attrs: Extra group-level attributes to inject into the dataset.
     """
 
     target: str | FSSpecTarget
     target_chunks: Dict[str, int] = field(default_factory=dict)
+    attrs: Dict[str] = field(default_factory=dict)
 
     def expand(self, pcoll: beam.PCollection) -> beam.PCollection:
         if isinstance(self.target, str):
@@ -369,7 +371,7 @@ class PrepareZarrTarget(beam.PTransform):
             target = self.target
         store = target.get_mapper()
         initialized_target = pcoll | beam.Map(
-            schema_to_zarr, target_store=store, target_chunks=self.target_chunks
+            schema_to_zarr, target_store=store, target_chunks=self.target_chunks, attrs=self.attrs
         )
         return initialized_target
 
@@ -479,6 +481,7 @@ class StoreToZarr(beam.PTransform, ZarrWriterMixin):
         `store_name` will be appended to this prefix to create a full path.
     :param target_chunks: Dictionary mapping dimension names to chunks sizes.
         If a dimension is a not named, the chunks will be inferred from the data.
+    :param attrs: Extra group-level attributes to inject into the dataset.
     """
 
     # TODO: make it so we don't have to explicitly specify combine_dims
@@ -489,6 +492,7 @@ class StoreToZarr(beam.PTransform, ZarrWriterMixin):
         default_factory=RequiredAtRuntimeDefault
     )
     target_chunks: Dict[str, int] = field(default_factory=dict)
+    attrs: Dict[str] = field(default_factory=dict)
 
     def expand(
         self,
@@ -500,7 +504,7 @@ class StoreToZarr(beam.PTransform, ZarrWriterMixin):
             target_chunks=self.target_chunks, schema=schema
         )
         target_store = schema | PrepareZarrTarget(
-            target=self.get_full_target(), target_chunks=self.target_chunks
+            target=self.get_full_target(), target_chunks=self.target_chunks, attrs=self.attrs
         )
         n_target_stores = rechunked_datasets | StoreDatasetFragments(target_store=target_store)
         singleton_target_store = (

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -85,7 +85,7 @@ def test_schema_to_template_ds_cftime():
     assert isinstance(dst.time.values[0], cftime.datetime)
 
 def test_schema_to_template_ds_attrs():
-    
+
     attrs = {'test_attr_key': 'test_attr_value'}
     ds = xr.decode_cf(
         xr.DataArray(
@@ -102,7 +102,6 @@ def test_schema_to_template_ds_attrs():
     
     schema = dataset_to_schema(ds)
     dst = schema_to_template_ds(schema, attrs=attrs)
-    import pdb; pdb.set_trace()
     assert dst.attrs['pangeo-forge:test_attr_key'] == 'test_attr_value'
     assert dst.attrs['original_attrs_key'] == 'original_attrs_value'
 

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -84,6 +84,27 @@ def test_schema_to_template_ds_cftime():
     assert ds.time.encoding.get("units") == dst.time.encoding.get("units")
     assert isinstance(dst.time.values[0], cftime.datetime)
 
+def test_schema_to_template_ds_attrs():
+    
+    attrs = {'test_attr_key': 'test_attr_value'}
+    ds = xr.decode_cf(
+        xr.DataArray(
+            [1],
+            dims=["time"],
+            coords={
+                "time": (
+                    "time",
+                    [1],
+                    {"units": "days since 1850-01-01 00:00:00", "calendar": "noleap"},
+                )
+            },attrs={'original_attrs_key': 'original_attrs_value'}
+        ).to_dataset(name="tas", promote_attrs=True))
+    
+    schema = dataset_to_schema(ds)
+    dst = schema_to_template_ds(schema, attrs=attrs)
+    import pdb; pdb.set_trace()
+    assert dst.attrs['pangeo-forge:test_attr_key'] == 'test_attr_value'
+    assert dst.attrs['original_attrs_key'] == 'original_attrs_value'
 
 def test_concat_accumulator():
     ds = make_ds(nt=3)


### PR DESCRIPTION
PR to implement the ability to inject `attrs` into the StoreToZarr transformation.
- Should preserve existing attrs
- Tags injected attrs with `pangeo-forge:` prefix. 

```python
| StoreToZarr(..., add_attrs={'some_name', 'some_value'})
```

<img width="772" alt="image" src="https://github.com/pangeo-forge/pangeo-forge-recipes/assets/22455466/87d0cfe6-2bc5-42dc-9bbf-d7450fea23b0">

https://github.com/pangeo-forge/pangeo-forge-recipes/issues/559