### PR TITLE
(Re)add twine to release deps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade setuptools setuptools-scm build
+          python -m pip install --upgrade setuptools setuptools-scm build twine
       - name: Build and publish
         env:
           TWINE_USERNAME: "__token__"


### PR DESCRIPTION
#627 accidentally removed `twine` from release deps. This fixes that.