### PR TITLE
Bump fsspec version for LazyReferenceMapper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "cftime",
     "dask >= 2021.11.2",
     "fastparquet",
-    "fsspec[http] >= 2021.6.0",
+    "fsspec[http] >= 2023.4.0",
     "h5netcdf",
     "h5py >= 3.3.0",
     "kerchunk >= 0.0.7",


### PR DESCRIPTION
#620 added a module-level import of LazyReferenceMapper from fsspec. AFAICT this is not available in fsspec until version `2023.4.0`, so bumping to that version here.

Noticed this because I was getting an ImportError in environments in which fsspec was already installed; it was not caught in CI for #620 because fsspec is installed into a clean environment in CI (so in CI the latest version is pulled).