### PR TITLE
WIP: Add RecipeConfig to Pass Around Injected Args

### DIFF
--- a/pangeo_forge_recipes/config.py
+++ b/pangeo_forge_recipes/config.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass, field
+from typing import Union, Optional
+
+from pangeo_forge_recipes.storage import FSSpecTarget, CacheFSSpecTarget
+from pangeo_forge_recipes.transforms import RequiredAtRuntimeDefault
+
+
+@dataclass
+class RecipeConfig:
+    """a simple class that SHOULD house all injection spec values
+    from `pangeo_forge_recipes.injections.py:get_injection_specs()`
+
+    This way folks can use it to pass injection spec values around
+    on to custom transforms or partials in their recipe:
+
+    ```python
+    from config import RecipeConfig
+
+    @dataclass
+    class MyCustomTransform(beam.PTransform):
+        # note that `MyCustomTransform` is not part of the
+        # pangeo_forge_recipes.injections.py:get_injection_specs()
+        # but now it can be used anyway in practice
+        target_root: None
+
+    recipe_config = RecipeConfig()
+
+    beam.Create() | MyCustomTransform(target_root=recipe_config.target_root)
+    ```
+    """
+    target_root: Union[str, FSSpecTarget, RequiredAtRuntimeDefault] = field(
+        default_factory=RequiredAtRuntimeDefault
+    )
+    cache: Optional[str | CacheFSSpecTarget] = None

--- a/pangeo_forge_recipes/config.py
+++ b/pangeo_forge_recipes/config.py
@@ -31,4 +31,4 @@ class RecipeConfig:
     target_root: Union[str, FSSpecTarget, RequiredAtRuntimeDefault] = field(
         default_factory=RequiredAtRuntimeDefault
     )
-    cache: Optional[str | CacheFSSpecTarget] = None
+    cache: Optional[Union[str, CacheFSSpecTarget]] = ""

--- a/pangeo_forge_recipes/config.py
+++ b/pangeo_forge_recipes/config.py
@@ -28,6 +28,7 @@ class RecipeConfig:
     beam.Create() | MyCustomTransform(target_root=recipe_config.target_root)
     ```
     """
+
     target_root: Union[str, FSSpecTarget, RequiredAtRuntimeDefault] = field(
         default_factory=RequiredAtRuntimeDefault
     )

--- a/pangeo_forge_recipes/injections.py
+++ b/pangeo_forge_recipes/injections.py
@@ -1,5 +1,9 @@
 def get_injection_specs():
     return {
+        "RecipeConfig": {
+            "target_root": "TARGET_STORAGE",
+            "cache": "INPUT_CACHE_STORAGE",
+        },
         "StoreToZarr": {
             "target_root": "TARGET_STORAGE",
         },


### PR DESCRIPTION
### Goal

See docs string in diff for an example or this [example recipe for local testing](https://github.com/ranchodeluxe/gpcp-from-gcs-feedstock/blob/test/integration/feedstock/recipe.py)#651 

I wanted to just inject the whole config dict into a simple variable at import or during ast traversal using `view_Assign` but I see we'd still have to modify all places where it's used so this seems to be the best option

Thoughts? IMHO This is makes things way more clear for the special use case that @sbquinlan brought up:
https://developmentseed.slack.com/archives/C01T1NJB98U/p1699662351418269


