### PR TITLE
Reuse `FSSpecTarget` Auth Credentials

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -33,6 +33,7 @@ jobs:
         runner-version: [
           "pangeo-forge-runner==0.9.1",
           "pangeo-forge-runner==0.9.2",
+          "pangeo-forge-runner==0.9.3",
         ]
     steps:
       - uses: actions/checkout@v4

--- a/examples/feedstock/hrrr_kerchunk_concat_step.py
+++ b/examples/feedstock/hrrr_kerchunk_concat_step.py
@@ -53,7 +53,6 @@ recipe = (
         concat_dims=pattern.concat_dims,
         identical_dims=identical_dims,
         precombine_inputs=True,
-        remote_protocol=remote_protocol,
     )
     | "Test dataset" >> beam.Map(test_ds)
 )

--- a/pangeo_forge_recipes/combiners.py
+++ b/pangeo_forge_recipes/combiners.py
@@ -65,7 +65,7 @@ class CombineMultiZarrToZarr(beam.CombineFn):
       along a dimension that does not exist in the individual inputs. In this latter
       case, precombining adds the additional dimension to the input so that its
       dimensionality will match that of the accumulator.
-    :param storage_options: Storage options dict to pass to the MultiZarrToZarr
+    :param target_options: Target options dict to pass to the MultiZarrToZarr
 
     """
 

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -459,7 +459,6 @@ class CombineReferences(beam.PTransform):
     precombine_inputs: bool = False
 
     def expand(self, references: beam.PCollection) -> beam.PCollection:
-
         return references | beam.CombineGlobally(
             CombineMultiZarrToZarr(
                 concat_dims=self.concat_dims,
@@ -482,9 +481,6 @@ class WriteReference(beam.PTransform, ZarrWriterMixin):
       will be appended to this prefix to create a full path.
     :param output_file_name: Name to give the output references file
       (``.json`` or ``.parquet`` suffix).
-    :param target_options: Storage options for opening target files
-    :param remote_options: Storage options for opening remote files
-    :param remote_protocol: If files are accessed over the network, provide the remote protocol
       over which they are accessed. e.g.: "s3", "gcp", "https", etc.
     :param mzz_kwargs: Additional kwargs to pass to ``kerchunk.combine.MultiZarrToZarr``.
     """
@@ -495,9 +491,6 @@ class WriteReference(beam.PTransform, ZarrWriterMixin):
         default_factory=RequiredAtRuntimeDefault
     )
     output_file_name: str = "reference.json"
-    target_options: Optional[Dict] = field(default_factory=lambda: {"anon": True})
-    remote_options: Optional[Dict] = field(default_factory=lambda: {"anon": True})
-    remote_protocol: Optional[str] = None
     mzz_kwargs: dict = field(default_factory=dict)
 
     def expand(self, references: beam.PCollection) -> beam.PCollection:
@@ -506,9 +499,6 @@ class WriteReference(beam.PTransform, ZarrWriterMixin):
             full_target=self.get_full_target(),
             concat_dims=self.concat_dims,
             output_file_name=self.output_file_name,
-            target_options=self.target_options,
-            remote_options=self.remote_options,
-            remote_protocol=self.remote_protocol,
             mzz_kwargs=self.mzz_kwargs,
         )
 
@@ -520,10 +510,6 @@ class WriteCombinedReference(beam.PTransform, ZarrWriterMixin):
     :param store_name: Zarr store will be created with this name under ``target_root``.
     :param concat_dims: Dimensions along which to concatenate inputs.
     :param identical_dims: Dimensions shared among all inputs.
-    :param target_options: Storage options for opening target files
-    :param remote_options: Storage options for opening remote files
-    :param remote_protocol: If files are accessed over the network, provide the remote protocol
-      over which they are accessed. e.g.: "s3", "gcp", "https", etc.
     :param mzz_kwargs: Additional kwargs to pass to ``kerchunk.combine.MultiZarrToZarr``.
     :param precombine_inputs: If ``True``, precombine each input with itself, using
       ``kerchunk.combine.MultiZarrToZarr``, before adding it to the accumulator.
@@ -543,9 +529,6 @@ class WriteCombinedReference(beam.PTransform, ZarrWriterMixin):
     store_name: str
     concat_dims: List[str]
     identical_dims: List[str]
-    target_options: Optional[Dict] = field(default_factory=lambda: {"anon": True})
-    remote_options: Optional[Dict] = field(default_factory=lambda: {"anon": True})
-    remote_protocol: Optional[str] = None
     mzz_kwargs: dict = field(default_factory=dict)
     precombine_inputs: bool = False
     target_root: Union[str, FSSpecTarget, RequiredAtRuntimeDefault] = field(
@@ -554,14 +537,18 @@ class WriteCombinedReference(beam.PTransform, ZarrWriterMixin):
     output_file_name: str = "reference.json"
 
     def expand(self, references: beam.PCollection) -> beam.PCollection[zarr.storage.FSStore]:
+        # unpack fsspec options that will be used below for transforms without dep injection
+        storage_options = self.target_root.fsspec_kwargs  # type: ignore[union-attr]
+        remote_protocol = self.target_root.get_fsspec_remote_protocol()  # type: ignore[union-attr]
+
         return (
             references
             | CombineReferences(
                 concat_dims=self.concat_dims,
                 identical_dims=self.identical_dims,
-                target_options=self.target_options,
-                remote_options=self.remote_options,
-                remote_protocol=self.remote_protocol,
+                target_options=storage_options,
+                remote_options=storage_options,
+                remote_protocol=remote_protocol,
                 mzz_kwargs=self.mzz_kwargs,
                 precombine_inputs=self.precombine_inputs,
             )
@@ -570,9 +557,6 @@ class WriteCombinedReference(beam.PTransform, ZarrWriterMixin):
                 concat_dims=self.concat_dims,
                 target_root=self.target_root,
                 output_file_name=self.output_file_name,
-                target_options=self.target_options,
-                remote_options=self.remote_options,
-                remote_protocol=self.remote_protocol,
             )
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ test = [
     "pytest-sugar",
     "pytest-timeout",
     "s3fs",
+    "gcsfs",
     "scipy",
 ]
 
@@ -76,7 +77,7 @@ line-length = 100
 
 [tool.isort]
 known_first_party = "pangeo_forge_recipes"
-known_third_party = ["aiohttp", "apache_beam", "cftime", "click", "dask", "fsspec", "kerchunk", "numpy", "pandas", "pytest", "pytest_lazyfixture", "s3fs", "xarray", "zarr"]
+known_third_party = ["aiohttp", "apache_beam", "cftime", "click", "dask", "fsspec", "gcsfs", "kerchunk", "numpy", "packaging", "pandas", "pytest", "pytest_lazyfixture", "s3fs", "xarray", "zarr"]
 multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -489,12 +489,6 @@ def tmp_target(tmpdir_factory):
 
 
 @pytest.fixture()
-def tmp_target_url(tmpdir_factory):
-    path = str(tmpdir_factory.mktemp("target.zarr"))
-    return path
-
-
-@pytest.fixture()
 def tmp_cache(tmpdir_factory):
     path = str(tmpdir_factory.mktemp("cache"))
     fs = fsspec.get_filesystem_class("file")()

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -36,7 +36,7 @@ def test_xarray_zarr(
     daily_xarray_dataset,
     netcdf_local_file_pattern,
     pipeline,
-    tmp_target_url,
+    tmp_target,
     target_chunks,
 ):
     pattern = netcdf_local_file_pattern
@@ -46,14 +46,14 @@ def test_xarray_zarr(
             | beam.Create(pattern.items())
             | OpenWithXarray(file_type=pattern.file_type)
             | StoreToZarr(
-                target_root=tmp_target_url,
+                target_root=tmp_target,
                 store_name="store",
                 target_chunks=target_chunks,
                 combine_dims=pattern.combine_dim_keys,
             )
         )
 
-    ds = xr.open_dataset(os.path.join(tmp_target_url, "store"), engine="zarr")
+    ds = xr.open_dataset(os.path.join(tmp_target.root_path, "store"), engine="zarr")
     assert ds.time.encoding["chunks"] == (target_chunks["time"],)
     xr.testing.assert_equal(ds.load(), daily_xarray_dataset)
 
@@ -62,7 +62,7 @@ def test_xarray_zarr_subpath(
     daily_xarray_dataset,
     netcdf_local_file_pattern_sequential,
     pipeline,
-    tmp_target_url,
+    tmp_target,
 ):
     pattern = netcdf_local_file_pattern_sequential
     with pipeline as p:
@@ -71,13 +71,13 @@ def test_xarray_zarr_subpath(
             | beam.Create(pattern.items())
             | OpenWithXarray(file_type=pattern.file_type)
             | StoreToZarr(
-                target_root=tmp_target_url,
+                target_root=tmp_target,
                 store_name="subpath",
                 combine_dims=pattern.combine_dim_keys,
             )
         )
 
-    ds = xr.open_dataset(os.path.join(tmp_target_url, "subpath"), engine="zarr")
+    ds = xr.open_dataset(os.path.join(tmp_target.root_path, "subpath"), engine="zarr")
     xr.testing.assert_equal(ds.load(), daily_xarray_dataset)
 
 
@@ -86,7 +86,7 @@ def test_reference_netcdf(
     daily_xarray_dataset,
     netcdf_local_file_pattern_sequential,
     pipeline,
-    tmp_target_url,
+    tmp_target,
     output_file_name,
 ):
     pattern = netcdf_local_file_pattern_sequential
@@ -98,13 +98,13 @@ def test_reference_netcdf(
             | OpenWithKerchunk(file_type=pattern.file_type)
             | WriteCombinedReference(
                 identical_dims=["lat", "lon"],
-                target_root=tmp_target_url,
+                target_root=tmp_target,
                 store_name=store_name,
                 concat_dims=["time"],
                 output_file_name=output_file_name,
             )
         )
-    full_path = os.path.join(tmp_target_url, store_name, output_file_name)
+    full_path = os.path.join(tmp_target.root_path, store_name, output_file_name)
     file_ext = os.path.splitext(output_file_name)[-1]
     if file_ext == ".json":
         mapper = fsspec.get_mapper("reference://", fo=full_path)
@@ -130,7 +130,7 @@ def test_reference_netcdf(
 )
 def test_reference_grib(
     pipeline,
-    tmp_target_url,
+    tmp_target,
 ):
     # This test adapted from:
     # https://github.com/fsspec/kerchunk/blob/33b00d60d02b0da3f05ccee70d6ebc42d8e09932/kerchunk/tests/test_grib.py#L14-L31
@@ -148,11 +148,11 @@ def test_reference_grib(
             | WriteCombinedReference(
                 concat_dims=[pattern.concat_dims[0]],
                 identical_dims=["latitude", "longitude"],
-                target_root=tmp_target_url,
+                target_root=tmp_target,
                 store_name=store_name,
             )
         )
-    full_path = os.path.join(tmp_target_url, store_name, "reference.json")
+    full_path = os.path.join(tmp_target.root_path, store_name, "reference.json")
     mapper = fsspec.get_mapper("reference://", fo=full_path)
     ds = xr.open_dataset(mapper, engine="zarr", backend_kwargs={"consolidated": False})
     assert ds.attrs["GRIB_centre"] == "cwao"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,9 +3,11 @@ import os
 import secrets
 import subprocess
 import time
+from importlib.metadata import version
 from pathlib import Path
 
 import pytest
+from packaging.version import parse as parse_version
 
 # Run only when the `--run-integration` option is passed.
 # See also `pytest_addoption` in conftest. Reference:
@@ -118,6 +120,10 @@ def test_integration(confpath_option: str, recipe_id: str, request):
     }
     if recipe_id in xfails:
         pytest.xfail(xfails[recipe_id])
+
+    runner_version = parse_version(version("pangeo-forge-runner"))
+    if recipe_id == "hrrr-kerchunk-concat-step" and runner_version <= parse_version("0.9.2"):
+        pytest.xfail("pg-runner version <= 0.9.2 didn't pass storage options")
 
     confpath = request.getfixturevalue(confpath_option)
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -8,7 +8,7 @@ from pytest_lazyfixture import lazy_fixture
 
 from pangeo_forge_recipes.aggregation import dataset_to_schema
 from pangeo_forge_recipes.patterns import FilePattern, FileType
-from pangeo_forge_recipes.storage import CacheFSSpecTarget
+from pangeo_forge_recipes.storage import CacheFSSpecTarget, FSSpecTarget
 from pangeo_forge_recipes.transforms import (
     DetermineSchema,
     IndexItems,
@@ -151,7 +151,7 @@ def test_OpenWithKerchunk_direct(pattern_direct, pipeline):
 
 
 @pytest.mark.parametrize("target_chunks", [{}, {"time": 1}, {"time": 2}, {"time": 2, "lon": 9}])
-def test_PrepareZarrTarget(pipeline, tmp_target_url, target_chunks):
+def test_PrepareZarrTarget(pipeline, tmp_target, target_chunks):
 
     ds = make_ds()
     schema = dataset_to_schema(ds)
@@ -181,7 +181,7 @@ def test_PrepareZarrTarget(pipeline, tmp_target_url, target_chunks):
 
     with pipeline as p:
         input = p | beam.Create([schema])
-        target = input | PrepareZarrTarget(target=tmp_target_url, target_chunks=target_chunks)
+        target = input | PrepareZarrTarget(target=tmp_target, target_chunks=target_chunks)
         assert_that(target, correct_target())
 
 
@@ -246,7 +246,7 @@ class OpenZarrStore(beam.PTransform):
 def test_StoreToZarr_emits_openable_fsstore(
     pipeline,
     netcdf_local_file_pattern_sequential,
-    tmp_target_url,
+    tmp_target,
 ):
     def is_xrdataset():
         def _is_xr_dataset(actual):
@@ -260,7 +260,7 @@ def test_StoreToZarr_emits_openable_fsstore(
     with pipeline as p:
         datasets = p | beam.Create(pattern.items()) | OpenWithXarray()
         target_store = datasets | StoreToZarr(
-            target_root=tmp_target_url,
+            target_root=tmp_target,
             store_name="test.zarr",
             combine_dims=pattern.combine_dim_keys,
         )
@@ -272,7 +272,7 @@ def test_StoreToZarr_emits_openable_fsstore(
 def test_StoreToZarr_dynamic_chunking_interface(
     pipeline: beam.Pipeline,
     netcdf_local_file_pattern_sequential: FilePattern,
-    tmp_target_url: str,
+    tmp_target: FSSpecTarget,
     daily_xarray_dataset: xr.Dataset,
     with_kws: bool,
 ):
@@ -305,7 +305,7 @@ def test_StoreToZarr_dynamic_chunking_interface(
     with pipeline as p:
         datasets = p | beam.Create(pattern.items()) | OpenWithXarray()
         target_store = datasets | StoreToZarr(
-            target_root=tmp_target_url,
+            target_root=tmp_target,
             store_name="test.zarr",
             combine_dims=pattern.combine_dim_keys,
             attrs={},


### PR DESCRIPTION
#### Addresses https://github.com/pangeo-forge/pangeo-forge-recipes/issues/666

Goal was to remove storage options from being passed in `WriteCombinedReference` b/c we already had access to the `target_root` being dep injected. But then for all nested `fsspec` instantiations within `WriteCombinedReference` we had to figure out how to return the original fsspec options from `target_root` and pass them along

#### Companion PR in Runner

https://github.com/pangeo-forge/pangeo-forge-runner/pull/163


#### Release Steps

- [x] Merge https://github.com/pangeo-forge/pangeo-forge-runner/pull/163 first
- [x] Do a `pangeo-forge-runner` 0.9.3 release
- [x] Change [this integration tests line](https://github.com/pangeo-forge/pangeo-forge-recipes/pull/668/files#diff-6fe485d23ef7802c7ae8d3147ecbdc7cda49acab6197da4a77e697a35b9b0af2R36) in this repo to point to `pangeo-forge-runner==0.9.3`
- [x] Make sure all tests pass
- [ ] Merge and Profit