### PR TITLE
WIP - [BugFix Attempt] ConsolidateMetadata 

### DIFF
--- a/pangeo_forge_recipes/writers.py
+++ b/pangeo_forge_recipes/writers.py
@@ -84,8 +84,10 @@ def consolidate_metadata(store: MutableMapping) -> MutableMapping:
     if isinstance(store, zarr.storage.FSStore):
         path = store.path
 
-    zc = zarr.consolidate_metadata(path)
-    return zc
+    zarr.convenience.consolidate_metadata(path)
+    # How do we update a parquet reference file?
+    path.fs.save_json(ref_path)
+    return path
 
 
 def store_dataset_fragment(

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -182,7 +182,6 @@ def test_reference_netcdf(
     netcdf_local_file_pattern_sequential,
     pipeline,
     tmp_target,
-    # why are we not using tmp_target?
     output_file_name,
 ):
     pattern = netcdf_local_file_pattern_sequential
@@ -203,6 +202,6 @@ def test_reference_netcdf(
         )
 
     full_path = os.path.join(tmp_target.root_path, store_name, output_file_name)
-
     mapper = fsspec.get_mapper("reference://", fo=full_path)
     assert zarr.open_consolidated(mapper)
+    assert xr.open_zarr(mapper, consolidated=True)


### PR DESCRIPTION
`ConsolidateMetadata` doesn't seem to be creating a `.zmetadata` in the reference recipe tests.

Based on Martin Durants comments here: https://github.com/fsspec/kerchunk/issues/240#issuecomment-1290739134, this PR updates how the `.zmetadata` is being created.

Some open questions:

- It seemed like the previous tests of `zarr.open_consolidated` were working...without a .zmetadata file?
- This method `path.fs.save_json(ref_path)` calls **save_json`**. How do we modify the parquet stores?


cc @abarciauskas-bgse @ranchodeluxe 