### PR TITLE
Failing tests due to pytest version

### DIFF
--- a/pangeo_forge_recipes/rechunking.py
+++ b/pangeo_forge_recipes/rechunking.py
@@ -277,4 +277,7 @@ def consolidate_dimension_coordinates(
         )
 
         new.attrs.update(attrs)
+        # Open question: Should this always be called
+        # or should we have the option of ConsolidateMetadata
+        zarr.consolidate_metadata(singleton_target_store)
     return singleton_target_store

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -598,7 +598,7 @@ class StoreToZarr(beam.PTransform, ZarrWriterMixin):
         default_factory=RequiredAtRuntimeDefault
     )
     target_chunks: Dict[str, int] = field(default_factory=dict)
-    consolidate_coords: bool = True
+    consolidate_dimension_coordinates: bool = False
     dynamic_chunking_fn: Optional[Callable[[xr.Dataset], dict]] = None
     dynamic_chunking_fn_kwargs: Optional[dict] = field(default_factory=dict)
     attrs: Dict[str, str] = field(default_factory=dict)
@@ -634,7 +634,7 @@ class StoreToZarr(beam.PTransform, ZarrWriterMixin):
             | beam.combiners.Sample.FixedSizeGlobally(1)
             | beam.FlatMap(lambda x: x)  # https://stackoverflow.com/a/47146582
         )
-        if self.consolidate_coords:
+        if self.consolidate_dimension_coordinates:
             singleton_target_store = singleton_target_store | ConsolidateDimensionCoordinates()
 
         return singleton_target_store

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -598,10 +598,10 @@ class StoreToZarr(beam.PTransform, ZarrWriterMixin):
         default_factory=RequiredAtRuntimeDefault
     )
     target_chunks: Dict[str, int] = field(default_factory=dict)
-    consolidate_dimension_coordinates: bool = False
     dynamic_chunking_fn: Optional[Callable[[xr.Dataset], dict]] = None
     dynamic_chunking_fn_kwargs: Optional[dict] = field(default_factory=dict)
     attrs: Dict[str, str] = field(default_factory=dict)
+    consolidate_dimension_coordinates: bool = False
 
     def __post_init__(self):
         if self.target_chunks and self.dynamic_chunking_fn:

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -606,12 +606,9 @@ class StoreToZarr(beam.PTransform, ZarrWriterMixin):
     dynamic_chunking_fn: Optional[Callable[[xr.Dataset], dict]] = None
     dynamic_chunking_fn_kwargs: Optional[dict] = field(default_factory=dict)
     attrs: Dict[str, str] = field(default_factory=dict)
-<<<<<<< HEAD
     consolidate_dimension_coordinates: bool = False
-=======
     consolidated_metadata: Optional[bool] = True
     encoding: Optional[dict] = field(default_factory=dict)
->>>>>>> main
 
     def __post_init__(self):
         if self.target_chunks and self.dynamic_chunking_fn:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "click",
-    "pytest",
+    "pytest<8.0.0",
     "pytest-cov",
     "pytest-xdist",
     "pytest-lazy-fixture",

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -195,10 +195,9 @@ def test_xarray_zarr_consolidate_coords(
                 consolidate_coords=consolidate_coords,
             )
         )
-    # TODO: This test needs to check if the consolidate_coords transform
-    # within StoreToZarr is consolidating the chunks of the coordinates
-    import pdb
 
-    pdb.set_trace()
     store = zarr.open(os.path.join(tmp_target_url, "subpath"))
-    ds = xr.open_zarr(os.path.join(tmp_target_url, "subpath"))
+    if not consolidate_coords:
+        assert store.time.chunks[0] != store.time.shape[0]
+    if consolidate_coords:
+        assert store.time.chunks[0] == store.time.shape[0]

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -175,12 +175,12 @@ def test_reference_grib(
     # xr.testing.assert_equal(ds.load(), ds2)
 
 
-@pytest.mark.parametrize("consolidate_coords", [False, True])
-def test_xarray_zarr_consolidate_coords(
+@pytest.mark.parametrize("consolidate_dimension_coordinates", [False, True])
+def test_xarray_zarr_consolidate_dimension_coordinates(
     netcdf_local_file_pattern_sequential,
     pipeline,
     tmp_target_url,
-    consolidate_coords,
+    consolidate_dimension_coordinates,
 ):
     pattern = netcdf_local_file_pattern_sequential
     with pipeline as p:
@@ -192,12 +192,12 @@ def test_xarray_zarr_consolidate_coords(
                 target_root=tmp_target_url,
                 store_name="subpath",
                 combine_dims=pattern.combine_dim_keys,
-                consolidate_coords=consolidate_coords,
+                consolidate_dimension_coordinates=consolidate_dimension_coordinates,
             )
         )
 
     store = zarr.open(os.path.join(tmp_target_url, "subpath"))
-    if not consolidate_coords:
+    if not consolidate_dimension_coordinates:
         assert store.time.chunks[0] != store.time.shape[0]
-    if consolidate_coords:
+    if consolidate_dimension_coordinates:
         assert store.time.chunks[0] == store.time.shape[0]

--- a/tests/test_rechunking.py
+++ b/tests/test_rechunking.py
@@ -281,7 +281,6 @@ def test_consolidate_dimension_coordinates():
     # If you don't provide these attrs,
     # consolidate_dimension_coordinates does not
     # raise an error, while Xarray does
-    group.attrs["_ARRAY_DIMENSIONS"] = ["time"]
     group.data.attrs["_ARRAY_DIMENSIONS"] = ["time"]
     group.time.attrs["_ARRAY_DIMENSIONS"] = ["time"]
 

--- a/tests/test_rechunking.py
+++ b/tests/test_rechunking.py
@@ -1,11 +1,20 @@
 import itertools
+import os
 import random
 from collections import namedtuple
+from tempfile import TemporaryDirectory
 
+import numpy as np
 import pytest
 import xarray as xr
+import zarr
 
-from pangeo_forge_recipes.rechunking import GroupKey, combine_fragments, split_fragment
+from pangeo_forge_recipes.rechunking import (
+    GroupKey,
+    combine_fragments,
+    consolidate_dimension_coordinates,
+    split_fragment,
+)
 from pangeo_forge_recipes.types import CombineOp, Dimension, Index, IndexedPosition, Position
 
 from .conftest import split_up_files_by_variable_and_day
@@ -258,3 +267,25 @@ def test_combine_fragments_errors():
     index1 = Index({Dimension("time", CombineOp.CONCAT): IndexedPosition(2)})
     with pytest.raises(ValueError, match="are not consistent"):
         _ = combine_fragments(group, [(index0, ds), (index1, ds)])
+
+
+def test_consolidate_dimension_coordinates():
+    td = TemporaryDirectory()
+    store_path = os.path.join(td.name + "tmp.zarr")
+    group = zarr.group(store=store_path, overwrite=True)
+    group.create(name="data", shape=100, chunks=10, dtype="i4")
+    group.create(name="time", shape=100, chunks=10, dtype="i4")
+    group.data[:] = np.random.randn(*group.data.shape)
+    group.time[:] = np.arange(100)
+
+    # If you don't provide these attrs,
+    # consolidate_dimension_coordinates does not
+    # raise an error, while Xarray does
+    group.attrs["_ARRAY_DIMENSIONS"] = ["time"]
+    group.data.attrs["_ARRAY_DIMENSIONS"] = ["time"]
+    group.time.attrs["_ARRAY_DIMENSIONS"] = ["time"]
+
+    consolidated_zarr = consolidate_dimension_coordinates(zarr.storage.FSStore(store_path))
+    store = zarr.open(consolidated_zarr)
+    assert store.time.chunks[0] == 100
+    assert store.data.chunks[0] == 10

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -310,6 +310,7 @@ def test_StoreToZarr_dynamic_chunking_interface(
             combine_dims=pattern.combine_dim_keys,
             attrs={},
             dynamic_chunking_fn=dynamic_chunking_fn,
+            consolidate_dimension_coordinates=False,
             **kws,
         )
         open_store = target_store | OpenZarrStore()


### PR DESCRIPTION
Test PR to check if pinning `pytest<8.0.0` fixes CI test failures.

ex: `ERROR tests/test_writers.py - AttributeError: 'CallSpec2' object has no attribute 'funcargs'`

https://github.com/pangeo-forge/pangeo-forge-recipes/actions/runs/7683300151/job/20938539769

cc @jbusecke 