### PR TITLE
Fix CombineReference merge ordering

### DIFF
--- a/examples/feedstock/hrrr_kerchunk_concat_step.py
+++ b/examples/feedstock/hrrr_kerchunk_concat_step.py
@@ -52,7 +52,6 @@ recipe = (
         store_name="hrrr-concat-step",
         concat_dims=pattern.concat_dims,
         identical_dims=identical_dims,
-        # precombine_inputs=True,
     )
     | "Test dataset" >> beam.Map(test_ds)
 )

--- a/examples/feedstock/hrrr_kerchunk_concat_step.py
+++ b/examples/feedstock/hrrr_kerchunk_concat_step.py
@@ -52,7 +52,7 @@ recipe = (
         store_name="hrrr-concat-step",
         concat_dims=pattern.concat_dims,
         identical_dims=identical_dims,
-        precombine_inputs=True,
+        # precombine_inputs=True,
     )
     | "Test dataset" >> beam.Map(test_ds)
 )

--- a/examples/feedstock/hrrr_kerchunk_concat_valid_time.py
+++ b/examples/feedstock/hrrr_kerchunk_concat_valid_time.py
@@ -68,7 +68,7 @@ recipe = (
         # fails due to: _pickle.PicklingError: Can't pickle <function drop_unknown
         #  at 0x290e46a70>: attribute lookup drop_unknown on __main__ failed
         mzz_kwargs=dict(preprocess=drop_unknown),
-        precombine_inputs=True,
+        # precombine_inputs=True,
     )
     | "Test dataset" >> beam.Map(test_ds)
 )

--- a/examples/feedstock/hrrr_kerchunk_concat_valid_time.py
+++ b/examples/feedstock/hrrr_kerchunk_concat_valid_time.py
@@ -68,7 +68,6 @@ recipe = (
         # fails due to: _pickle.PicklingError: Can't pickle <function drop_unknown
         #  at 0x290e46a70>: attribute lookup drop_unknown on __main__ failed
         mzz_kwargs=dict(preprocess=drop_unknown),
-        # precombine_inputs=True,
     )
     | "Test dataset" >> beam.Map(test_ds)
 )

--- a/pangeo_forge_recipes/combiners.py
+++ b/pangeo_forge_recipes/combiners.py
@@ -56,18 +56,6 @@ class CombineZarrRefs(beam.CombineFn):
     :param remote_protocol: If files are accessed over the network, provide the remote protocol
       over which they are accessed. e.g.: "s3", "gcp", "https", etc.
     :mzz_kwargs: Additional kwargs to pass to ``kerchunk.combine.MultiZarrToZarr``.
-    TODO: precombine_inputs is very adhoc here, perhaps should be resolved in other ways
-        flatmapping at a prior stage resolves the awkward list[dict] item type, so absolves
-        GRIB2 inputs of their need for this
-    :precombine_inputs: If ``True``, precombine each input with itself, using
-      ``kerchunk.combine.MultiZarrToZarr``, before adding it to the accumulator.
-      Used for multi-message GRIB2 inputs, which produce > 1 reference when opened
-      with kerchunk's ``scan_grib`` function, and therefore need to be consolidated
-      into a single reference before adding to the accumulator. Also used for inputs
-      consisting of single reference, for cases where the output dataset concatenates
-      along a dimension that does not exist in the individual inputs. In this latter
-      case, precombining adds the additional dimension to the input so that its
-      dimensionality will match that of the accumulator.
     :param target_options: Target options dict to pass to the MultiZarrToZarr
 
     """

--- a/pangeo_forge_recipes/combiners.py
+++ b/pangeo_forge_recipes/combiners.py
@@ -98,7 +98,7 @@ class CombineZarrRefs(beam.CombineFn):
         return accumulator
 
     def merge_accumulators(self, accumulators: list[list[dict]]) -> list[dict]:
-        return [item for accumulator in accumulators for item in accumulator]
+        return [self.to_mzz(accumulator).translate() for accumulator in accumulators]
 
     def extract_output(self, accumulator: list[dict]) -> fsspec.FSMap:
         return fsspec.filesystem(

--- a/pangeo_forge_recipes/combiners.py
+++ b/pangeo_forge_recipes/combiners.py
@@ -47,8 +47,8 @@ class CombineXarraySchemas(beam.CombineFn):
 
 
 @dataclass
-class CombineMultiZarrToZarr(beam.CombineFn):
-    """A beam ``CombineFn`` for combining Kerchunk ``MultiZarrToZarr`` objects.
+class CombineZarrRefs(beam.CombineFn):
+    """A beam ``CombineFn`` for combining Kerchunk reference objects.
 
     :param concat_dims: Dimensions along which to concatenate inputs.
     :param identical_dims: Dimensions shared among all inputs.
@@ -56,6 +56,9 @@ class CombineMultiZarrToZarr(beam.CombineFn):
     :param remote_protocol: If files are accessed over the network, provide the remote protocol
       over which they are accessed. e.g.: "s3", "gcp", "https", etc.
     :mzz_kwargs: Additional kwargs to pass to ``kerchunk.combine.MultiZarrToZarr``.
+    TODO: precombine_inputs is very adhoc here, perhaps should be resolved in other ways
+        flatmapping at a prior stage resolves the awkward list[dict] item type, so absolves
+        GRIB2 inputs of their need for this
     :precombine_inputs: If ``True``, precombine each input with itself, using
       ``kerchunk.combine.MultiZarrToZarr``, before adding it to the accumulator.
       Used for multi-message GRIB2 inputs, which produce > 1 reference when opened
@@ -75,7 +78,6 @@ class CombineMultiZarrToZarr(beam.CombineFn):
     remote_options: Optional[Dict] = field(default_factory=lambda: {"anon": True})
     remote_protocol: Optional[str] = None
     mzz_kwargs: dict = field(default_factory=dict)
-    precombine_inputs: bool = False
 
     def to_mzz(self, references):
         return MultiZarrToZarr(
@@ -88,25 +90,20 @@ class CombineMultiZarrToZarr(beam.CombineFn):
             **self.mzz_kwargs,
         )
 
-    def create_accumulator(self):
-        return None
+    def create_accumulator(self) -> list[dict]:
+        return []
 
-    def add_input(self, accumulator: MultiZarrToZarr, item: list[dict]) -> MultiZarrToZarr:
-        item = item if not self.precombine_inputs else [self.to_mzz(item).translate()]
-        if not accumulator:
-            references = item
-        else:
-            references = [accumulator.translate()] + item
-        return self.to_mzz(references)
+    def add_input(self, accumulator: list[dict], item: dict) -> list[dict]:
+        accumulator.append(item)
+        return accumulator
 
-    def merge_accumulators(self, accumulators: Sequence[MultiZarrToZarr]) -> MultiZarrToZarr:
-        references = [a.translate() for a in accumulators]
-        return self.to_mzz(references)
+    def merge_accumulators(self, accumulators: list[list[dict]]) -> list[dict]:
+        return [item for accumulator in accumulators for item in accumulator]
 
-    def extract_output(self, accumulator: MultiZarrToZarr) -> MultiZarrToZarr:
+    def extract_output(self, accumulator: list[dict]) -> fsspec.FSMap:
         return fsspec.filesystem(
             "reference",
-            fo=accumulator.translate(),
+            fo=self.to_mzz(accumulator).translate(),
             storage_options={
                 "remote_protocol": self.remote_protocol,
                 "skip_instance_cache": True,

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -483,24 +483,15 @@ class CombineReferences(beam.PTransform):
         global_position_min_max_count: Tuple[int, int, int],
     ) -> Tuple[int, dict]:
         """
-        Assigns a bucket based on the index position to preserve data order during merging via
-        GroupByKey.
+        Assigns a bucket based on the index position to order data during GroupByKey.
 
-        This method calculates which 'bucket' or segment an individual reference belongs to,
-        based on its position within a global sorting dimension. This is crucial for operations
-        that need to maintain data order, especially when dealing with large datasets that are
-        processed in parts.
-
-        Parameters:
-        - indexed_references: A tuple containing the index and the reference dictionary. The index
-        is used to determine the reference's position within the global data order.
-        - global_position_min_max_count: A tuple containing the global minimum and maximum
-        positions and the total count of references. These values are used to determine the range
-        and distribution of buckets.
-
-        Returns:
-        - A tuple where the first element is the bucket number (an integer) assigned to the
-        reference, and the second element is the original reference dictionary.
+        :param indexed_references: A tuple containing the index and the reference dictionary. The
+            index is used to determine the reference's position within the global data order.
+        :param global_position_min_max_count: A tuple containing the global minimum and maximum
+            positions and the total count of references. These values are used to determine the
+            range and distribution of buckets.
+        :returns: A tuple where the first element is the bucket number (an integer) assigned to the
+            reference, and the second element is the original reference dictionary.
         """
         idx = indexed_references[0]
         ref = indexed_references[1]

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -463,10 +463,13 @@ class CombineReferences(beam.PTransform):
     mzz_kwargs: dict = field(default_factory=dict)
     # precombine_inputs: bool = False
 
+    def identity(self, element):
+        return element
+
     def expand(self, reference_lists: beam.PCollection) -> beam.PCollection:
         return (
             reference_lists
-            | beam.FlatMap(lambda x: x)
+            | beam.FlatMap(self.identity)
             | beam.CombineGlobally(
                 CombineZarrRefs(
                     concat_dims=self.concat_dims,
@@ -558,7 +561,7 @@ class WriteCombinedReference(beam.PTransform, ZarrWriterMixin):
                 remote_options=storage_options,
                 remote_protocol=remote_protocol,
                 mzz_kwargs=self.mzz_kwargs,
-                precombine_inputs=self.precombine_inputs,
+                # precombine_inputs=self.precombine_inputs,
             )
             | WriteReference(
                 store_name=self.store_name,

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -208,7 +208,6 @@ class OpenWithKerchunk(beam.PTransform):
     storage_options: Optional[Dict] = field(default_factory=dict)
     remote_protocol: Optional[str] = None
     kerchunk_open_kwargs: Optional[dict] = field(default_factory=dict)
-    desired_buckets: int = 5
 
     def expand(self, pcoll):
         return pcoll | "Open with Kerchunk" >> beam.MapTuple(

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import random
 import sys
 from dataclasses import dataclass, field
@@ -14,11 +15,13 @@ else:
     from typing import Concatenate, ParamSpec
 
 import apache_beam as beam
+import fsspec
 import xarray as xr
 import zarr
+from kerchunk.combine import MultiZarrToZarr
 
 from .aggregation import XarraySchema, dataset_to_schema, schema_to_template_ds, schema_to_zarr
-from .combiners import CombineXarraySchemas, CombineZarrRefs
+from .combiners import CombineXarraySchemas, MinMaxCountCombineFn
 from .openers import open_url, open_with_kerchunk, open_with_xarray
 from .patterns import CombineOp, Dimension, FileType, Index, augment_index_with_start_stop
 from .rechunking import combine_fragments, consolidate_dimension_coordinates, split_fragment
@@ -197,12 +200,6 @@ class OpenWithKerchunk(beam.PTransform):
     :param kerchunk_open_kwargs: Additional kwargs to pass to kerchunk opener. Any kwargs which
       are specific to a particular input file type should be passed here;  e.g.,
       ``{"filter": ...}`` for GRIB; ``{"max_chunk_size": ...}`` for NetCDF3, etc.
-    :param drop_keys: If True, remove Pangeo Forge's FilePattern keys from the output PCollection
-      before returning. This is the default behavior, which is used for cases where the output
-      PCollection of references is passed to the ``CombineReferences`` transform for creation of a
-      Kerchunk reference dataset as the target dataset of the pipeline. If this transform is used
-      for other use cases (e.g., opening inputs for creation of another target dataset type), you
-      may want to set this option to False to preserve the keys on the output PCollection.
     """
 
     # passed directly to `open_with_kerchunk`
@@ -211,12 +208,10 @@ class OpenWithKerchunk(beam.PTransform):
     storage_options: Optional[Dict] = field(default_factory=dict)
     remote_protocol: Optional[str] = None
     kerchunk_open_kwargs: Optional[dict] = field(default_factory=dict)
-
-    # not passed to `open_with_kerchunk`
-    drop_keys: bool = True
+    desired_buckets: int = 5
 
     def expand(self, pcoll):
-        refs = pcoll | "Open with Kerchunk" >> beam.MapTuple(
+        return pcoll | "Open with Kerchunk" >> beam.MapTuple(
             lambda k, v: (
                 k,
                 open_with_kerchunk(
@@ -229,8 +224,6 @@ class OpenWithKerchunk(beam.PTransform):
                 ),
             )
         )
-
-        return refs if not self.drop_keys else refs | beam.Values()
 
 
 @dataclass
@@ -443,7 +436,8 @@ class CombineReferences(beam.PTransform):
     :param remote_options: Storage options for opening remote files
     :param remote_protocol: If files are accessed over the network, provide the remote protocol
       over which they are accessed. e.g.: "s3", "gcp", "https", etc.
-    :mzz_kwargs: Additional kwargs to pass to ``kerchunk.combine.MultiZarrToZarr``.
+    :param max_refs_per_merge: Maximum number of references to combine in a single merge operation.
+    :param mzz_kwargs: Additional kwargs to pass to ``kerchunk.combine.MultiZarrToZarr``.
     """
 
     concat_dims: List[str]
@@ -451,25 +445,80 @@ class CombineReferences(beam.PTransform):
     target_options: Optional[Dict] = field(default_factory=lambda: {"anon": True})
     remote_options: Optional[Dict] = field(default_factory=lambda: {"anon": True})
     remote_protocol: Optional[str] = None
+    max_refs_per_merge: int = 5
     mzz_kwargs: dict = field(default_factory=dict)
 
-    def identity(self, element):
-        return element
+    def to_mzz(self, references):
+        """Converts references into a MultiZarrToZarr object with configured parameters."""
+        return MultiZarrToZarr(
+            references,
+            concat_dims=self.concat_dims,
+            identical_dims=self.identical_dims,
+            target_options=self.target_options,
+            remote_options=self.remote_options,
+            remote_protocol=self.remote_protocol,
+            **self.mzz_kwargs,
+        )
+
+    def handle_gribs(self, indexed_references: Tuple[Index, list[dict]]) -> Tuple[Index, dict]:
+        """Handles the special case of GRIB format files by combining multiple references."""
+
+        references = indexed_references[1]
+        idx = indexed_references[0]
+        if len(references) > 1:
+            ref = self.to_mzz(references).translate()
+            return (idx, ref)
+        elif len(references) == 1:
+            return (idx, references[0])
+        else:
+            raise ValueError("No references produced for {idx}. Expected at least 1.")
+
+    def bucket_by_position(
+        self, indexed_references: Tuple[Index, dict], global_position_min_max_count
+    ) -> Tuple[int, dict]:
+        """Assigns a bucket based on index position to help preserve data order."""
+        idx = indexed_references[0]
+        ref = indexed_references[1]
+        global_min, global_max, global_count = global_position_min_max_count
+        sort_dimension = self.concat_dims[-1]
+        position = idx.find_position(sort_dimension)
+        range_size = global_max - global_min
+        num_buckets = math.ceil(global_count / self.max_refs_per_merge)
+        bucket_size = range_size / num_buckets
+        bucket = int((position - global_min) / bucket_size)
+        return bucket, ref
+
+    def global_combine_refs(self, refs) -> fsspec.FSMap:
+        """Performs a global combination of references to produce the final dataset."""
+        return fsspec.filesystem(
+            "reference",
+            fo=self.to_mzz(refs).translate(),
+            storage_options={
+                "remote_protocol": self.remote_protocol,
+                "skip_instance_cache": True,
+            },
+        ).get_mapper()
 
     def expand(self, reference_lists: beam.PCollection) -> beam.PCollection:
+        min_max_count_positions = (
+            reference_lists
+            | "Get just the positions"
+            >> beam.MapTuple(lambda k, v: k.find_position(self.concat_dims[-1]))
+            | "Get minimum/maximum positions" >> beam.CombineGlobally(MinMaxCountCombineFn())
+        )
         return (
             reference_lists
-            | beam.FlatMap(self.identity)
-            | beam.CombineGlobally(
-                CombineZarrRefs(
-                    concat_dims=self.concat_dims,
-                    identical_dims=self.identical_dims,
-                    target_options=self.target_options,
-                    remote_options=self.remote_options,
-                    remote_protocol=self.remote_protocol,
-                    mzz_kwargs=self.mzz_kwargs,
-                ),
+            | "Handle special case of gribs" >> beam.Map(self.handle_gribs)
+            | "Bucket to preserve order"
+            >> beam.Map(
+                self.bucket_by_position,
+                global_position_min_max_count=beam.pvalue.AsSingleton(min_max_count_positions),
             )
+            | "Group by buckets for ordering" >> beam.GroupByKey()
+            | "Distributed reduce" >> beam.MapTuple(lambda k, refs: self.to_mzz(refs).translate())
+            | "Assign global key for collecting to executor" >> beam.Map(lambda ref: (None, ref))
+            | "Group globally" >> beam.GroupByKey()
+            | "Global reduce" >> beam.MapTuple(lambda k, refs: self.global_combine_refs(refs))
         )
 
 

--- a/pangeo_forge_recipes/types.py
+++ b/pangeo_forge_recipes/types.py
@@ -73,6 +73,13 @@ class Index(Dict[Dimension, Position]):
         else:
             return possible_concat_dims[0]
 
+    def find_position(self, dim_name: str) -> int:
+        dimension = self.find_concat_dim(dim_name)
+        if dimension:
+            return self[dimension].value
+        else:
+            raise ValueError(f"No dimension found with name {dim_name}")
+
 
 # A convenience type to represent an indexed value
 T = TypeVar("T")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,13 +130,7 @@ def make_local_paths(
 
     for ds, path in zip(datasets, full_paths):
         save_method = getattr(ds, method)
-        # Question: Should we enable explicity chunking when saving to netcdf?
-        # by default it is encoding data with chunks, such as "chunks": [2,18,36]. It might be useful to set explicit chunks.
-        # encoding = {
-        #     'foo': {'chunksizes': (1, 2, 2)},
-        #     'bar': {'chunksizes': (1, 2, 2)}
-        # }
-        save_method(path, **kwargs)  # encoding=encoding, **kwargs)
+        save_method(path, **kwargs)
 
     # xr.save_mfdataset(datasets, [str(path) for path in full_paths])
     items_per_file = {"D": 1, "2D": 2}[items_per_file]
@@ -244,7 +238,6 @@ def pipeline(scope="session"):
 
 @pytest.fixture
 def pipeline_parallel(scope="session"):
-    # TODO: make this True and fix the weird ensuing type check errors
     options = PipelineOptions(
         runtime_type_check=False,
         direct_num_workers=4,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,7 +130,13 @@ def make_local_paths(
 
     for ds, path in zip(datasets, full_paths):
         save_method = getattr(ds, method)
-        save_method(path, **kwargs)
+        # Question: Should we enable explicity chunking when saving to netcdf?
+        # by default it is encoding data with chunks, such as "chunks": [2,18,36]. It might be useful to set explicit chunks.
+        # encoding = {
+        #     'foo': {'chunksizes': (1, 2, 2)},
+        #     'bar': {'chunksizes': (1, 2, 2)}
+        # }
+        save_method(path, **kwargs)  # encoding=encoding, **kwargs)
 
     # xr.save_mfdataset(datasets, [str(path) for path in full_paths])
     items_per_file = {"D": 1, "2D": 2}[items_per_file]
@@ -232,6 +238,19 @@ def pattern(request):
 def pipeline(scope="session"):
     # TODO: make this True and fix the weird ensuing type check errors
     options = PipelineOptions(runtime_type_check=False)
+    with TestPipeline(options=options) as p:
+        yield p
+
+
+@pytest.fixture
+def pipeline_parallel(scope="session"):
+    # TODO: make this True and fix the weird ensuing type check errors
+    options = PipelineOptions(
+        runtime_type_check=False,
+        direct_num_workers=4,
+        direct_running_mode="multi_processing",
+        runner="DirectRunner",
+    )
     with TestPipeline(options=options) as p:
         yield p
 

--- a/tests/test_combiners.py
+++ b/tests/test_combiners.py
@@ -1,3 +1,5 @@
+from typing import Generator
+
 import apache_beam as beam
 import fsspec
 import pytest
@@ -202,13 +204,13 @@ def _is_expected_dataset(expected_ds):
 def test_CombineReferences(netcdf_local_paths_sequential_1d, pipeline):
     urls = netcdf_local_paths_sequential_1d[0]
 
-    def generate_refs(urls) -> list[dict]:
+    def generate_refs(urls) -> Generator[dict, None, None]:
         for url in urls:
             with fsspec.open(url) as inf:
                 h5chunks = SingleHdf5ToZarr(inf, url, inline_threshold=100)
                 yield h5chunks.translate()
 
-    refs = generate_refs(urls)
+    refs = list(generate_refs(urls))
     concat_dims = ["time"]
     identical_dims = ["lat", "lon"]
     mzz = MultiZarrToZarr(

--- a/tests/test_combiners.py
+++ b/tests/test_combiners.py
@@ -10,7 +10,7 @@ from kerchunk.hdf import SingleHdf5ToZarr
 from pytest_lazyfixture import lazy_fixture
 
 from pangeo_forge_recipes.aggregation import dataset_to_schema
-from pangeo_forge_recipes.combiners import CombineMultiZarrToZarr, CombineXarraySchemas
+from pangeo_forge_recipes.combiners import CombineXarraySchemas, CombineZarrRefs
 from pangeo_forge_recipes.patterns import FilePattern
 from pangeo_forge_recipes.transforms import DatasetToSchema, DetermineSchema, _NestDim
 from pangeo_forge_recipes.types import CombineOp, Dimension, Index
@@ -202,13 +202,13 @@ def _is_expected_dataset(expected_ds):
 def test_CombineReferences(netcdf_local_paths_sequential_1d, pipeline):
     urls = netcdf_local_paths_sequential_1d[0]
 
-    def generate_refs(urls):
+    def generate_refs(urls) -> list[dict]:
         for url in urls:
             with fsspec.open(url) as inf:
                 h5chunks = SingleHdf5ToZarr(inf, url, inline_threshold=100)
-                yield [h5chunks.translate()]
+                yield h5chunks.translate()
 
-    refs = [ref[0] for ref in generate_refs(urls)]
+    refs = generate_refs(urls)
     concat_dims = ["time"]
     identical_dims = ["lat", "lon"]
     mzz = MultiZarrToZarr(
@@ -221,7 +221,7 @@ def test_CombineReferences(netcdf_local_paths_sequential_1d, pipeline):
     with pipeline as p:
         input = p | beam.Create(generate_refs(urls))
         output = input | beam.CombineGlobally(
-            CombineMultiZarrToZarr(concat_dims=concat_dims, identical_dims=identical_dims)
+            CombineZarrRefs(concat_dims=concat_dims, identical_dims=identical_dims)
         )
 
         assert_that(output, _is_expected_dataset(expected_dataset))

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -122,6 +122,45 @@ def test_reference_netcdf(
         xr.testing.assert_equal(ds.load(), daily_xarray_dataset)
 
 
+def test_reference_netcdf_parallel(
+    daily_xarray_dataset,
+    netcdf_local_file_pattern_sequential_multivariable,
+    pipeline_parallel,
+    tmp_target,
+    output_file_name="reference.json",
+):
+    pattern = netcdf_local_file_pattern_sequential_multivariable
+    store_name = "daily-xarray-dataset"
+    with pipeline_parallel as p:
+        (
+            p
+            | beam.Create(pattern.items())
+            | OpenWithKerchunk(file_type=pattern.file_type)
+            | WriteCombinedReference(
+                identical_dims=["lat", "lon"],
+                target_root=tmp_target,
+                store_name=store_name,
+                concat_dims=["time"],
+                output_file_name=output_file_name,
+            )
+        )
+    full_path = os.path.join(tmp_target.root_path, store_name, output_file_name)
+
+    # Question: Should we add a test here for the number of keys in the reference
+    # or is that moot since the xarray dataset equality check is already in place?
+    # import json
+    # refs = json.loads(open(full_path).read())
+    # key_len = len(refs.keys())
+    # 25 keys expected for netcdf_local_paths_sequential_multivariable_1d: 2 variables * 10 timesteps + .zattrs + .zgroup + lat + lon + time
+    # 35 keys expected for netcdf_local_paths_sequential_multivariable_2d
+    file_ext = os.path.splitext(output_file_name)[-1]
+
+    if file_ext == ".json":
+        mapper = fsspec.get_mapper("reference://", fo=full_path)
+        ds = xr.open_dataset(mapper, engine="zarr", backend_kwargs={"consolidated": False})
+        xr.testing.assert_equal(ds.load(), daily_xarray_dataset)
+
+
 @pytest.mark.xfail(
     importlib.util.find_spec("cfgrib") is None,
     reason=(

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -146,13 +146,6 @@ def test_reference_netcdf_parallel(
         )
     full_path = os.path.join(tmp_target.root_path, store_name, output_file_name)
 
-    # Question: Should we add a test here for the number of keys in the reference
-    # or is that moot since the xarray dataset equality check is already in place?
-    # import json
-    # refs = json.loads(open(full_path).read())
-    # key_len = len(refs.keys())
-    # 25 keys expected for netcdf_local_paths_sequential_multivariable_1d: 2 variables * 10 timesteps + .zattrs + .zgroup + lat + lon + time
-    # 35 keys expected for netcdf_local_paths_sequential_multivariable_2d
     file_ext = os.path.splitext(output_file_name)[-1]
 
     if file_ext == ".json":

--- a/tests/test_openers.py
+++ b/tests/test_openers.py
@@ -9,6 +9,7 @@ from pytest_lazyfixture import lazy_fixture
 from pangeo_forge_recipes.openers import open_url, open_with_xarray
 from pangeo_forge_recipes.patterns import FileType
 from pangeo_forge_recipes.transforms import OpenWithKerchunk
+from pangeo_forge_recipes.types import Index
 
 
 @pytest.fixture(
@@ -160,9 +161,9 @@ def test_direct_open_with_xarray(public_url_and_type, load, xarray_open_kwargs):
 
 
 def is_valid_inline_threshold():
-    def _is_valid_inline_threshold(references):
-
-        assert isinstance(references[0][0]["refs"]["lat/0"], list)
+    def _is_valid_inline_threshold(indexed_references):
+        assert isinstance(indexed_references[0][0], Index)
+        assert isinstance(indexed_references[0][1][0]["refs"]["lat/0"], list)
 
     return _is_valid_inline_threshold
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -18,7 +18,7 @@ from pangeo_forge_recipes.transforms import (
     Rechunk,
     StoreToZarr,
 )
-from pangeo_forge_recipes.types import CombineOp
+from pangeo_forge_recipes.types import CombineOp, Index
 
 from .data_generation import make_ds
 
@@ -121,20 +121,24 @@ def test_OpenWithXarray_via_fsspec_load(pcoll_opened_files, pipeline):
         assert_that(loaded_dsets, is_xr_dataset(in_memory=True))
 
 
-def is_list_of_refs_dicts():
-    def _is_list_of_refs_dicts(refs):
-        for r in refs[0]:
-            assert isinstance(r, dict)
-            assert "refs" in r
+def is_list_of_idx_refs_dicts():
+    def _is_list_of_idx_refs_dicts(results):
+        for result in results:
+            idx = result[0]
+            references = result[1]
+            test_ref = references[0]
+            assert isinstance(idx, Index)
+            assert isinstance(test_ref, dict)
+            assert "refs" in test_ref
 
-    return _is_list_of_refs_dicts
+    return _is_list_of_idx_refs_dicts
 
 
 def test_OpenWithKerchunk_via_fsspec(pcoll_opened_files, pipeline):
     input, pattern, cache_url = pcoll_opened_files
     with pipeline as p:
         output = p | input | OpenWithKerchunk(pattern.file_type)
-        assert_that(output, is_list_of_refs_dicts())
+        assert_that(output, is_list_of_idx_refs_dicts())
 
 
 def test_OpenWithKerchunk_direct(pattern_direct, pipeline):
@@ -147,7 +151,7 @@ def test_OpenWithKerchunk_direct(pattern_direct, pipeline):
             | beam.Create(pattern_direct.items())
             | OpenWithKerchunk(file_type=pattern_direct.file_type)
         )
-        assert_that(output, is_list_of_refs_dicts())
+        assert_that(output, is_list_of_idx_refs_dicts())
 
 
 @pytest.mark.parametrize("target_chunks", [{}, {"time": 1}, {"time": 2}, {"time": 2, "lon": 9}])


### PR DESCRIPTION
precombine_inputs is kind of awkward and it is really only used (so far as I can tell) to deal with the fact that GRIB2 reads will produce a list of ZARR refs. This could be simpler. ~We could just flatmap over the list of lists, producing a list of references that can be accumulated, shipped to the driver, and then combined via MultiZarrToZarr all at once.~

FlatMap is gone, as it is convenient to keep grib references grouped under their key until `CombineReferences` is called. Instead, MapTuple is used and we hang onto keys. Keys are used to construct batches that keep neighboring data on the same worker and merging is handled much more consciously than is possible in a `beam.CombineGlobally`

~This also happens to be much closer to the strategy described as 'tree reduction' in the kerchunk docs and implemented in their auto_dask method so maybe it will resolve some *very weird* bugs that currently appear to be associated with the (bad) assumption that MultiZarrToZarr merger has the properties of associativity and idempotence. Maybe 🤞?~
We now have testing (courtesy of @abarciauskas-bgse) which verifies correctness.

This also supersedes #688 as it resolves the item pluralization issue @abarciauskas-bgse identified
Incorporates #691