### PR TITLE
Use MapTuple, put higher-order index type in `types` file

### DIFF
--- a/pangeo_forge_recipes/combiners.py
+++ b/pangeo_forge_recipes/combiners.py
@@ -1,14 +1,14 @@
 import operator
 from dataclasses import dataclass, field
 from functools import reduce
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence
 
 import apache_beam as beam
 import fsspec
 from kerchunk.combine import MultiZarrToZarr
 
 from .aggregation import XarrayCombineAccumulator, XarraySchema
-from .types import CombineOp, Dimension, Index
+from .types import CombineOp, Dimension, Index, Indexed
 
 
 @dataclass
@@ -28,7 +28,7 @@ class CombineXarraySchemas(beam.CombineFn):
         concat_dim = self.dimension.name if self.dimension.operation == CombineOp.CONCAT else None
         return XarrayCombineAccumulator(concat_dim=concat_dim)
 
-    def add_input(self, accumulator: XarrayCombineAccumulator, item: Tuple[Index, XarraySchema]):
+    def add_input(self, accumulator: XarrayCombineAccumulator, item: Indexed[XarraySchema]):
         index, schema = item
         position = self.get_position(index)
         accumulator.add_input(schema, position)

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -23,6 +23,7 @@ from .openers import open_url, open_with_kerchunk, open_with_xarray
 from .patterns import CombineOp, Dimension, FileType, Index, augment_index_with_start_stop
 from .rechunking import combine_fragments, consolidate_dimension_coordinates, split_fragment
 from .storage import CacheFSSpecTarget, FSSpecTarget
+from .types import Indexed
 from .writers import (
     ZarrWriterMixin,
     consolidate_metadata,
@@ -64,12 +65,11 @@ logger = logging.getLogger(__name__)
 # Ideally each PTransform should be a simple Map or DoFn calling out to function
 # from other modules
 
-
 T = TypeVar("T")
-Indexed = Tuple[Index, T]
+IndexedArg = Indexed[T]
 
 R = TypeVar("R")
-IndexedReturn = Tuple[Index, R]
+IndexedReturn = Indexed[R]
 
 P = ParamSpec("P")
 
@@ -87,30 +87,9 @@ class RequiredAtRuntimeDefault:
     pass
 
 
-# TODO: replace with beam.MapTuple?
-def _add_keys(
-    func: Callable[Concatenate[T, P], R],
-) -> Callable[Concatenate[Indexed, P], IndexedReturn]:
-    """Convenience decorator to remove and re-add keys to items in a Map"""
-    annotations = func.__annotations__.copy()
-    arg_name, annotation = next(iter(annotations.items()))
-    annotations[arg_name] = Tuple[Index, annotation]
-    return_annotation = annotations["return"]
-    annotations["return"] = Tuple[Index, return_annotation]
-
-    # @wraps(func)  # doesn't work for some reason
-    def wrapper(arg, *args: P.args, **kwargs: P.kwargs):
-        key, item = arg
-        result = func(item, *args, **kwargs)
-        return key, result
-
-    wrapper.__annotations__ = annotations
-    return wrapper
-
-
 def _add_keys_iter(
     func: Callable[Concatenate[T, P], R],
-) -> Callable[Concatenate[Iterable[Indexed], P], Iterator[IndexedReturn]]:
+) -> Callable[Concatenate[Iterable[IndexedArg], P], Iterator[IndexedReturn]]:
     """Convenience decorator to iteratively remove and re-add keys to items in a FlatMap"""
     annotations = func.__annotations__.copy()
     arg_name, annotation = next(iter(annotations.items()))
@@ -156,7 +135,9 @@ class MapWithConcurrencyLimit(beam.PTransform):
 
     def expand(self, pcoll):
         return (
-            pcoll | self.fn.__name__ >> beam.Map(_add_keys(self.fn), *self.args, **self.kwargs)
+            pcoll
+            | self.fn.__name__
+            >> beam.MapTuple(lambda k, v: (k, self.fn(v, *self.args, **self.kwargs)))
             if not self.max_concurrency
             else (
                 pcoll
@@ -164,7 +145,7 @@ class MapWithConcurrencyLimit(beam.PTransform):
                 | beam.GroupByKey()
                 | beam.Values()
                 | f"{self.fn.__name__} (max_concurrency={self.max_concurrency})"
-                >> beam.FlatMap(_add_keys_iter(self.fn), *self.args, **self.kwargs)
+                >> beam.FlatMap(lambda k, v: _add_keys_iter(self.fn), *self.args, **self.kwargs)
             )
         )
 
@@ -235,13 +216,18 @@ class OpenWithKerchunk(beam.PTransform):
     drop_keys: bool = True
 
     def expand(self, pcoll):
-        refs = pcoll | "Open with Kerchunk" >> beam.Map(
-            _add_keys(open_with_kerchunk),
-            file_type=self.file_type,
-            inline_threshold=self.inline_threshold,
-            storage_options=self.storage_options,
-            remote_protocol=self.remote_protocol,
-            kerchunk_open_kwargs=self.kerchunk_open_kwargs,
+        refs = pcoll | "Open with Kerchunk" >> beam.MapTuple(
+            lambda k, v: (
+                k,
+                open_with_kerchunk(
+                    v,
+                    file_type=self.file_type,
+                    inline_threshold=self.inline_threshold,
+                    storage_options=self.storage_options,
+                    remote_protocol=self.remote_protocol,
+                    kerchunk_open_kwargs=self.kerchunk_open_kwargs,
+                ),
+            )
         )
 
         return refs if not self.drop_keys else refs | beam.Values()
@@ -266,12 +252,17 @@ class OpenWithXarray(beam.PTransform):
     xarray_open_kwargs: Optional[dict] = field(default_factory=dict)
 
     def expand(self, pcoll):
-        return pcoll | "Open with Xarray" >> beam.Map(
-            _add_keys(open_with_xarray),
-            file_type=self.file_type,
-            load=self.load,
-            copy_to_local=self.copy_to_local,
-            xarray_open_kwargs=self.xarray_open_kwargs,
+        return pcoll | "Open with Xarray" >> beam.MapTuple(
+            lambda k, v: (
+                k,
+                open_with_xarray(
+                    v,
+                    file_type=self.file_type,
+                    load=self.load,
+                    copy_to_local=self.copy_to_local,
+                    xarray_open_kwargs=self.xarray_open_kwargs,
+                ),
+            )
         )
 
 
@@ -299,7 +290,7 @@ class _NestDim(beam.PTransform):
 @dataclass
 class DatasetToSchema(beam.PTransform):
     def expand(self, pcoll: beam.PCollection) -> beam.PCollection:
-        return pcoll | beam.Map(_add_keys(dataset_to_schema))
+        return pcoll | beam.MapTuple(lambda k, v: (k, dataset_to_schema(v)))
 
 
 @dataclass
@@ -313,7 +304,7 @@ class DetermineSchema(beam.PTransform):
     combine_dims: List[Dimension]
 
     def expand(self, pcoll: beam.PCollection) -> beam.PCollection:
-        schemas = pcoll | beam.Map(_add_keys(dataset_to_schema))
+        schemas = pcoll | beam.MapTuple(lambda k, v: (k, dataset_to_schema(v)))
         cdims = self.combine_dims.copy()
         while len(cdims) > 0:
             last_dim = cdims.pop()

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -145,7 +145,7 @@ class MapWithConcurrencyLimit(beam.PTransform):
                 | beam.GroupByKey()
                 | beam.Values()
                 | f"{self.fn.__name__} (max_concurrency={self.max_concurrency})"
-                >> beam.FlatMap(lambda k, v: _add_keys_iter(self.fn), *self.args, **self.kwargs)
+                >> beam.FlatMap(_add_keys_iter(self.fn), *self.args, **self.kwargs)
             )
         )
 

--- a/pangeo_forge_recipes/types.py
+++ b/pangeo_forge_recipes/types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple, TypeVar
 
 
 class CombineOp(Enum):
@@ -72,3 +72,8 @@ class Index(Dict[Dimension, Position]):
             return None
         else:
             return possible_concat_dims[0]
+
+
+# A convenience type to represent an indexed value
+T = TypeVar("T")
+Indexed = Tuple[Index, T]


### PR DESCRIPTION
Saw a TODO that was absolutely the right path forward regarding `_add_keys`: don't use it because it is more confusing to modify functions rather than simply compose functions via MapTuple

This also moves the higher order type `Indexed` into types as that is likely to find reuse (elsewhere, as it did in this PR)