### PR TITLE
Avoid globalcombine if associativity isn't assured

### DIFF
--- a/pangeo_forge_recipes/combiners.py
+++ b/pangeo_forge_recipes/combiners.py
@@ -1,11 +1,10 @@
 import operator
-from dataclasses import dataclass, field
+import sys
+from dataclasses import dataclass
 from functools import reduce
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Sequence, Tuple
 
 import apache_beam as beam
-import fsspec
-from kerchunk.combine import MultiZarrToZarr
 
 from .aggregation import XarrayCombineAccumulator, XarraySchema
 from .types import CombineOp, Dimension, Index
@@ -46,54 +45,32 @@ class CombineXarraySchemas(beam.CombineFn):
         return accumulator.schema
 
 
-@dataclass
-class CombineZarrRefs(beam.CombineFn):
-    """A beam ``CombineFn`` for combining Kerchunk reference objects.
+def build_reduce_fn(accumulate_op, merge_op, initializer):
+    """Factory to construct reducers without so much ceremony"""
 
-    :param concat_dims: Dimensions along which to concatenate inputs.
-    :param identical_dims: Dimensions shared among all inputs.
-    :param remote_options: Storage options for opening remote files
-    :param remote_protocol: If files are accessed over the network, provide the remote protocol
-      over which they are accessed. e.g.: "s3", "gcp", "https", etc.
-    :mzz_kwargs: Additional kwargs to pass to ``kerchunk.combine.MultiZarrToZarr``.
-    :param target_options: Target options dict to pass to the MultiZarrToZarr
+    class AnonymousCombineFn(beam.CombineFn):
+        def create_accumulator(self):
+            return initializer
 
-    """
+        def add_input(self, accumulator, input):
+            return accumulate_op(accumulator, input)
 
-    concat_dims: List[str]
-    identical_dims: List[str]
-    target_options: Optional[Dict] = field(default_factory=lambda: {"anon": True})
-    remote_options: Optional[Dict] = field(default_factory=lambda: {"anon": True})
-    remote_protocol: Optional[str] = None
-    mzz_kwargs: dict = field(default_factory=dict)
+        def merge_accumulators(self, accumulators):
+            acc = accumulators[0]
+            for accumulator in accumulators[1:]:
+                acc = merge_op(acc, accumulator)
+            return acc
 
-    def to_mzz(self, references):
-        return MultiZarrToZarr(
-            references,
-            concat_dims=self.concat_dims,
-            identical_dims=self.identical_dims,
-            target_options=self.target_options,
-            remote_options=self.remote_options,
-            remote_protocol=self.remote_protocol,
-            **self.mzz_kwargs,
-        )
+        def extract_output(self, accumulator):
+            return accumulator
 
-    def create_accumulator(self) -> list[dict]:
-        return []
+    return AnonymousCombineFn
 
-    def add_input(self, accumulator: list[dict], item: dict) -> list[dict]:
-        accumulator.append(item)
-        return accumulator
 
-    def merge_accumulators(self, accumulators: list[list[dict]]) -> list[dict]:
-        return [self.to_mzz(accumulator).translate() for accumulator in accumulators]
-
-    def extract_output(self, accumulator: list[dict]) -> fsspec.FSMap:
-        return fsspec.filesystem(
-            "reference",
-            fo=self.to_mzz(accumulator).translate(),
-            storage_options={
-                "remote_protocol": self.remote_protocol,
-                "skip_instance_cache": True,
-            },
-        ).get_mapper()
+# Find minimum/maximum/count values
+# Count done as a slight optimization to avoid multiple passes across the distribution
+MinMaxCountCombineFn = build_reduce_fn(
+    accumulate_op=lambda acc, input: (min(acc[0], input), max(acc[1], input), acc[2] + 1),
+    merge_op=lambda accL, accR: (min(accL[0], accR[0]), max(accL[1], accR[1]), accL[2] + accR[2]),
+    initializer=(sys.maxsize, -sys.maxsize, 0),
+)

--- a/pangeo_forge_recipes/types.py
+++ b/pangeo_forge_recipes/types.py
@@ -72,3 +72,10 @@ class Index(Dict[Dimension, Position]):
             return None
         else:
             return possible_concat_dims[0]
+
+    def find_position(self, dim_name: str) -> int:
+        dimension = self.find_concat_dim(dim_name)
+        if dimension:
+            return self[dimension].value
+        else:
+            raise ValueError(f"No dimension found with name {dim_name}")

--- a/tests/test_openers.py
+++ b/tests/test_openers.py
@@ -9,6 +9,7 @@ from pytest_lazyfixture import lazy_fixture
 from pangeo_forge_recipes.openers import open_url, open_with_xarray
 from pangeo_forge_recipes.patterns import FileType
 from pangeo_forge_recipes.transforms import OpenWithKerchunk
+from pangeo_forge_recipes.types import Index
 
 
 @pytest.fixture(
@@ -160,9 +161,9 @@ def test_direct_open_with_xarray(public_url_and_type, load, xarray_open_kwargs):
 
 
 def is_valid_inline_threshold():
-    def _is_valid_inline_threshold(references):
-
-        assert isinstance(references[0][0]["refs"]["lat/0"], list)
+    def _is_valid_inline_threshold(indexed_references):
+        assert isinstance(indexed_references[0][0], Index)
+        assert isinstance(indexed_references[0][1][0]["refs"]["lat/0"], list)
 
     return _is_valid_inline_threshold
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -18,7 +18,7 @@ from pangeo_forge_recipes.transforms import (
     Rechunk,
     StoreToZarr,
 )
-from pangeo_forge_recipes.types import CombineOp
+from pangeo_forge_recipes.types import CombineOp, Index
 
 from .data_generation import make_ds
 
@@ -121,20 +121,24 @@ def test_OpenWithXarray_via_fsspec_load(pcoll_opened_files, pipeline):
         assert_that(loaded_dsets, is_xr_dataset(in_memory=True))
 
 
-def is_list_of_refs_dicts():
-    def _is_list_of_refs_dicts(refs):
-        for r in refs[0]:
-            assert isinstance(r, dict)
-            assert "refs" in r
+def is_list_of_idx_refs_dicts():
+    def _is_list_of_idx_refs_dicts(results):
+        for result in results:
+            idx = result[0]
+            references = result[1]
+            test_ref = references[0]
+            assert isinstance(idx, Index)
+            assert isinstance(test_ref, dict)
+            assert "refs" in test_ref
 
-    return _is_list_of_refs_dicts
+    return _is_list_of_idx_refs_dicts
 
 
 def test_OpenWithKerchunk_via_fsspec(pcoll_opened_files, pipeline):
     input, pattern, cache_url = pcoll_opened_files
     with pipeline as p:
         output = p | input | OpenWithKerchunk(pattern.file_type)
-        assert_that(output, is_list_of_refs_dicts())
+        assert_that(output, is_list_of_idx_refs_dicts())
 
 
 def test_OpenWithKerchunk_direct(pattern_direct, pipeline):
@@ -147,7 +151,7 @@ def test_OpenWithKerchunk_direct(pattern_direct, pipeline):
             | beam.Create(pattern_direct.items())
             | OpenWithKerchunk(file_type=pattern_direct.file_type)
         )
-        assert_that(output, is_list_of_refs_dicts())
+        assert_that(output, is_list_of_idx_refs_dicts())
 
 
 @pytest.mark.parametrize("target_chunks", [{}, {"time": 1}, {"time": 2}, {"time": 2, "lon": 9}])


### PR DESCRIPTION
This PR addresses a critical issue found in the kerchunk merging behavior provided by `CombineReferences`. In place of a `CombineGlobally` we've now got a single pass over inputs get some statistics about `Index` position which are used to intelligently group references so that they are merged in consecutive batches. 