### PR TITLE
Retain original _FillValue in encoding

### DIFF
--- a/pangeo_forge_recipes/aggregation.py
+++ b/pangeo_forge_recipes/aggregation.py
@@ -147,7 +147,12 @@ def _combine_attrs(a1: dict, a2: dict) -> dict:
     common_attrs = set(a1) & set(a2)
     new_attrs = {}
     for key in common_attrs:
-        if isinstance(a1[key], np.floating) and isinstance(a2[key], np.floating) and np.isnan(a1[key]) and np.isnan(a2[key]):
+        if (
+            isinstance(a1[key], np.floating)
+            and isinstance(a2[key], np.floating)
+            and np.isnan(a1[key])
+            and np.isnan(a2[key])
+        ):
             new_attrs[key] = a1[key]
         elif a1[key] == a2[key]:
             new_attrs[key] = a1[key]

--- a/pangeo_forge_recipes/aggregation.py
+++ b/pangeo_forge_recipes/aggregation.py
@@ -31,7 +31,6 @@ def dataset_to_schema(ds: xr.Dataset) -> XarraySchema:
     # Remove redundant encoding options
     for v in ds.variables:
         for option in ["source"]:
-            # TODO: should be okay to remove _FillValue?
             if option in ds[v].encoding:
                 del ds[v].encoding[option]
     d = ds.to_dict(data=False, encoding=True)

--- a/pangeo_forge_recipes/aggregation.py
+++ b/pangeo_forge_recipes/aggregation.py
@@ -30,7 +30,7 @@ def dataset_to_schema(ds: xr.Dataset) -> XarraySchema:
 
     # Remove redundant encoding options
     for v in ds.variables:
-        for option in ["_FillValue", "source"]:
+        for option in ["source"]:
             # TODO: should be okay to remove _FillValue?
             if option in ds[v].encoding:
                 del ds[v].encoding[option]
@@ -147,7 +147,9 @@ def _combine_attrs(a1: dict, a2: dict) -> dict:
     common_attrs = set(a1) & set(a2)
     new_attrs = {}
     for key in common_attrs:
-        if a1[key] == a2[key]:
+        if isinstance(a1[key], np.floating) and isinstance(a2[key], np.floating) and np.isnan(a1[key]) and np.isnan(a2[key]):
+            new_attrs[key] = a1[key]
+        elif a1[key] == a2[key]:
             new_attrs[key] = a1[key]
     return new_attrs
 

--- a/pangeo_forge_recipes/aggregation.py
+++ b/pangeo_forge_recipes/aggregation.py
@@ -146,6 +146,7 @@ def _combine_attrs(a1: dict, a2: dict) -> dict:
     common_attrs = set(a1) & set(a2)
     new_attrs = {}
     for key in common_attrs:
+        # treat NaNs as equal in the attrs
         if (
             isinstance(a1[key], np.floating)
             and isinstance(a2[key], np.floating)

--- a/tests/test_combiners.py
+++ b/tests/test_combiners.py
@@ -104,6 +104,7 @@ def _strip_keys(item):
 
 
 def _assert_schema_equal(a, b):
+    # This is used instead of ``assert dict1 == dict2`` so that NaNs are treated as equal.
     assert set(a.keys()) == set(b.keys())
 
     for key, value1 in a.items():

--- a/tests/test_combiners.py
+++ b/tests/test_combiners.py
@@ -1,13 +1,14 @@
 import logging
 
 import apache_beam as beam
+import numpy as np
 import pytest
 import xarray as xr
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from pytest_lazyfixture import lazy_fixture
-import numpy as np
+
 from pangeo_forge_recipes.aggregation import dataset_to_schema
 from pangeo_forge_recipes.combiners import CombineXarraySchemas
 from pangeo_forge_recipes.patterns import FilePattern
@@ -101,18 +102,25 @@ def _get_concat_dim(pattern):
 def _strip_keys(item):
     return item[1]
 
+
 def _assert_schema_equal(a, b):
     assert set(a.keys()) == set(b.keys())
 
     for key, value1 in a.items():
         value2 = b[key]
-        if isinstance(value1, np.floating) and isinstance(value2, np.floating) and np.isnan(value1) and np.isnan(value2):
+        if (
+            isinstance(value1, np.floating)
+            and isinstance(value2, np.floating)
+            and np.isnan(value1)
+            and np.isnan(value2)
+        ):
             continue
 
         if isinstance(value1, dict) and isinstance(value2, dict):
             _assert_schema_equal(value1, value2)
         else:
             assert value1 == value2
+
 
 def has_correct_schema(expected_schema):
     def _check_results(actual):


### PR DESCRIPTION
This is a follow-up to https://github.com/pangeo-forge/pangeo-forge-recipes/issues/471 that adds `_FillValue` to the retained encoding options. Based on https://github.com/pangeo-forge/pangeo-forge-recipes/pull/471#discussion_r1072218998, `_FillValue` was initially excluded because it causes the tests to fail when asserting that the expected and actual schemas are equal. That fails because it's common to specify `_FillValue` as `np.nan` and nans do not equal each other. This PR adds a `_assert_schema_equal` that will treat NaNs in the schema as equal, so that the original `_FillValue` can be retained.

This PR is a prerequisite to #669 because we need to make all encoding options stored in `.zmetadata` follow [valid JSON](https://datatracker.ietf.org/doc/html/rfc8259).