### PR TITLE
Change dims to sizes to suppress future warning

### DIFF
--- a/pangeo_forge_recipes/rechunking.py
+++ b/pangeo_forge_recipes/rechunking.py
@@ -195,7 +195,7 @@ def combine_fragments(
         (
             dim.name,
             [index[dim].value for index in all_indexes],
-            [ds.dims[dim.name] for ds in all_dsets],
+            [ds.sizes[dim.name] for ds in all_dsets],
         )
         for dim in concat_dims
     ]


### PR DESCRIPTION
This PR changes the use of `ds.dims` to `ds.sizes` to avoid the following future warning. The motivation for this PR is that this recurring warning can make it harder to notice other important warnings when running recipes.
```
python3.11/site-packages/pangeo_forge_recipes/rechunking.py:198: FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.
```