### PR TITLE
Crush warning about ds.dims deprecation

### DIFF
--- a/pangeo_forge_recipes/rechunking.py
+++ b/pangeo_forge_recipes/rechunking.py
@@ -57,7 +57,7 @@ def split_fragment(
             dimsize = getattr(index[concat_dim], "dimsize", 0)
             concat_position = index[concat_dim]
             start = concat_position.value
-            stop = start + ds.dims[dim_name]
+            stop = start + ds.sizes[dim_name]
             dim_slice = slice(start, stop)
             rechunked_concat_dims.append(concat_dim)
         else:
@@ -65,7 +65,7 @@ def split_fragment(
             # in the fragment index, then we can assume that the entire span of
             # that dimension is present in the dataset.
             # This would arise e.g. when decimating a contiguous dimension
-            dimsize = ds.dims[dim_name]
+            dimsize = ds.sizes[dim_name]
             dim_slice = slice(0, dimsize)
 
         target_chunks_and_dims[dim_name] = (chunk, dimsize)
@@ -195,7 +195,7 @@ def combine_fragments(
         (
             dim.name,
             [index[dim].value for index in all_indexes],
-            [ds.dims[dim.name] for ds in all_dsets],
+            [ds.sizes[dim.name] for ds in all_dsets],
         )
         for dim in concat_dims
     ]

--- a/tests/test_rechunking.py
+++ b/tests/test_rechunking.py
@@ -142,7 +142,7 @@ def test_split_multidim():
 
     nt = 2
     ds = make_ds(nt=nt)
-    nlat = ds.dims["lat"]
+    nlat = ds.sizes["lat"]
     dimension = Dimension("time", CombineOp.CONCAT)
     index = Index({dimension: IndexedPosition(0, dimsize=nt)})
 
@@ -211,7 +211,7 @@ def test_combine_fragments_multidim(time_chunk, lat_chunk):
 
     nt = 10
     ds = make_ds(nt=nt)
-    ny = ds.dims["lat"]
+    ny = ds.sizes["lat"]
 
     fragments = []
     time_dim = Dimension("time", CombineOp.CONCAT)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -209,7 +209,7 @@ def test_rechunk(
     def correct_chunks():
         def _check_chunks(actual):
             for index, ds in actual:
-                actual_chunked_dims = {dim: ds.dims[dim] for dim in target_chunks}
+                actual_chunked_dims = {dim: ds.sizes[dim] for dim in target_chunks}
                 assert all(
                     position.indexed
                     for dimension, position in index.items()


### PR DESCRIPTION
Got a bunch of these:
```
 FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.
```
Hopefully this will be an easy fix