### PR TITLE
Adds StoreToPyramid in get_injection_specs

### DIFF
--- a/pangeo_forge_recipes/injections.py
+++ b/pangeo_forge_recipes/injections.py
@@ -3,6 +3,9 @@ def get_injection_specs():
         "StoreToZarr": {
             "target_root": "TARGET_STORAGE",
         },
+        "StoreToPyramid": {
+            "target_root": "TARGET_STORAGE",
+        },
         "WriteReference": {
             "target_root": "TARGET_STORAGE",
         },


### PR DESCRIPTION
Tiny PR that adds the ability for the runner to inject `TARGET_STORAGE` into the `StoreToPyramid` [transform ](https://github.com/carbonplan/pangeo-forge-ndpyramid).