### PR TITLE
Optional support for synchronous HTTP filesystem

### DIFF
--- a/pangeo_forge_recipes/openers.py
+++ b/pangeo_forge_recipes/openers.py
@@ -18,6 +18,7 @@ def open_url(
     cache: Optional[CacheFSSpecTarget] = None,
     secrets: Optional[Dict] = None,
     open_kwargs: Optional[Dict] = None,
+    fsspec_sync_patch: bool = False,
 ) -> OpenFileType:
     """Open a string-based URL with fsspec.
 
@@ -29,10 +30,10 @@ def open_url(
     kw = open_kwargs or {}
     if cache is not None:
         # this has side effects
-        cache.cache_file(url, secrets, **kw)
+        cache.cache_file(url, secrets, fsspec_sync_patch, **kw)
         open_file = cache.open_file(url, mode="rb")
     else:
-        open_file = _get_opener(url, secrets, **kw)
+        open_file = _get_opener(url, secrets, fsspec_sync_patch, **kw)
     return open_file
 
 

--- a/pangeo_forge_recipes/storage.py
+++ b/pangeo_forge_recipes/storage.py
@@ -234,7 +234,6 @@ def _get_opener(fname, secrets, fsspec_sync_patch, **open_kwargs):
         SyncHTTPFileSystem.overwrite_async_registration()
         logger.debug("Synchronous HTTP implementation enabled.")
 
-
     fname = fname if not secrets else _add_query_string_secrets(fname, secrets)
     return fsspec.open(fname, mode="rb", **open_kwargs)
 

--- a/pangeo_forge_recipes/storage.py
+++ b/pangeo_forge_recipes/storage.py
@@ -229,15 +229,11 @@ def _add_query_string_secrets(fname: str, secrets: dict) -> str:
 def _get_opener(fname, secrets, fsspec_sync_patch, **open_kwargs):
     if fsspec_sync_patch:
         logger.debug("Attempting to enable synchronous filesystem implementations in FSSpec")
-        try:
-            from httpfs_sync.core import SyncHTTPFileSystem
+        from httpfs_sync.core import SyncHTTPFileSystem
 
-            SyncHTTPFileSystem.overwrite_async_registration()
-            logger.debug("Synchronous HTTP implementation enabled.")
-        except ImportError:
-            logger.warning(
-                "httpfs_sync could not be imported. Falling back to async http implementation."
-            )
+        SyncHTTPFileSystem.overwrite_async_registration()
+        logger.debug("Synchronous HTTP implementation enabled.")
+
 
     fname = fname if not secrets else _add_query_string_secrets(fname, secrets)
     return fsspec.open(fname, mode="rb", **open_kwargs)

--- a/pangeo_forge_recipes/storage.py
+++ b/pangeo_forge_recipes/storage.py
@@ -22,12 +22,6 @@ logger = logging.getLogger(__name__)
 OpenFileType = Union[fsspec.core.OpenFile, fsspec.spec.AbstractBufferedFile, io.IOBase]
 
 
-def _get_url_size(fname, secrets, **open_kwargs):
-    with _get_opener(fname, secrets, **open_kwargs) as of:
-        size = of.size
-    return size
-
-
 def _copy_btw_filesystems(input_opener, output_opener, BLOCK_SIZE=10_000_000):
     with input_opener as source:
         with output_opener as target:
@@ -192,18 +186,21 @@ class FlatFSSpecTarget(FSSpecTarget):
 class CacheFSSpecTarget(FlatFSSpecTarget):
     """Alias for FlatFSSpecTarget"""
 
-    def cache_file(self, fname: str, secrets: Optional[dict], **open_kwargs) -> None:
+    def cache_file(
+        self, fname: str, secrets: Optional[dict], fsspec_sync_patch=False, **open_kwargs
+    ) -> None:
         # check and see if the file already exists in the cache
         logger.info(f"Caching file '{fname}'")
+        input_opener = _get_opener(fname, secrets, fsspec_sync_patch, **open_kwargs)
+
         if self.exists(fname):
             cached_size = self.size(fname)
-            remote_size = _get_url_size(fname, secrets, **open_kwargs)
+            remote_size = input_opener.size
             if cached_size == remote_size:
                 # TODO: add checksumming here
                 logger.info(f"File '{fname}' is already cached")
                 return
 
-        input_opener = _get_opener(fname, secrets, **open_kwargs)
         target_opener = self.open(fname, mode="wb")
         logger.info(f"Copying remote file '{fname}' to cache")
         _copy_btw_filesystems(input_opener, target_opener)
@@ -228,7 +225,19 @@ def _add_query_string_secrets(fname: str, secrets: dict) -> str:
     return urlunparse(parsed)
 
 
-def _get_opener(fname, secrets, **open_kwargs):
+def _get_opener(fname, secrets, fsspec_sync_patch, **open_kwargs):
+    if fsspec_sync_patch:
+        logger.debug("Attempting to enable synchronous filesystem implementations in FSSpec")
+        try:
+            from httpfs_sync.core import SyncHTTPFileSystem
+
+            SyncHTTPFileSystem.overwrite_async_registration()
+            logger.debug("Synchronous HTTP implementation enabled.")
+        except ImportError:
+            logger.warning(
+                "httpfs_sync could not be imported. Falling back to async http implementation."
+            )
+
     fname = fname if not secrets else _add_query_string_secrets(fname, secrets)
     return fsspec.open(fname, mode="rb", **open_kwargs)
 

--- a/pangeo_forge_recipes/storage.py
+++ b/pangeo_forge_recipes/storage.py
@@ -195,7 +195,8 @@ class CacheFSSpecTarget(FlatFSSpecTarget):
 
         if self.exists(fname):
             cached_size = self.size(fname)
-            remote_size = input_opener.size
+            with input_opener as of:
+                remote_size = of.size
             if cached_size == remote_size:
                 # TODO: add checksumming here
                 logger.info(f"File '{fname}' is already cached")

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -165,7 +165,7 @@ class OpenURLWithFSSpec(beam.PTransform):
         kws = dict(
             cache=cache,
             secrets=self.secrets,
-            fsspec_sync_patch=self.sync_patch,
+            fsspec_sync_patch=self.fsspec_sync_patch,
             open_kwargs=self.open_kwargs,
         )
         return pcoll | MapWithConcurrencyLimit(

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -145,12 +145,16 @@ class OpenURLWithFSSpec(beam.PTransform):
     :param secrets: If provided these secrets will be injected into the URL as a query string.
     :param open_kwargs: Extra arguments passed to fsspec.open.
     :param max_concurrency: Max concurrency for this transform.
+    :param fsspec_sync_patch: Experimental. Likely slower. When enabled, this attempts to
+        replace asynchronous code with synchronous implementations to potentially address
+        deadlocking issues. cf. https://github.com/h5py/h5py/issues/2019
     """
 
     cache: Optional[str | CacheFSSpecTarget] = None
     secrets: Optional[dict] = None
     open_kwargs: Optional[dict] = None
     max_concurrency: Optional[int] = None
+    fsspec_sync_patch: bool = False
 
     def expand(self, pcoll):
         if isinstance(self.cache, str):
@@ -161,12 +165,11 @@ class OpenURLWithFSSpec(beam.PTransform):
         kws = dict(
             cache=cache,
             secrets=self.secrets,
+            fsspec_sync_patch=self.sync_patch,
             open_kwargs=self.open_kwargs,
         )
         return pcoll | MapWithConcurrencyLimit(
-            open_url,
-            kwargs=kws,
-            max_concurrency=self.max_concurrency,
+            open_url, kwargs=kws, max_concurrency=self.max_concurrency
         )
 
 

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -169,7 +169,9 @@ class OpenURLWithFSSpec(beam.PTransform):
             open_kwargs=self.open_kwargs,
         )
         return pcoll | MapWithConcurrencyLimit(
-            open_url, kwargs=kws, max_concurrency=self.max_concurrency
+            open_url,
+            kwargs=kws,
+            max_concurrency=self.max_concurrency,
         )
 
 


### PR DESCRIPTION
This PR adds a flag that enables the experimental support for a synchronous alternative to the HTTP/S filesystems provided by FSSpec. Fairly extensive profiling with xarray reveals that this is quite likely slower than the default case but enabling it allows us to reduce the async/concurrency surface area of the code which may avoid or at least help debug potential deadlocking issues.