### PR TITLE
cli as an alternative to `pangeo-forge-runner`

### DIFF
--- a/examples/new-feedstock/meta.yaml
+++ b/examples/new-feedstock/meta.yaml
@@ -1,0 +1,18 @@
+title: "Baltic Sea - Sea Surface Temperature Analysis L4"
+description: "For the Baltic Sea- The DMI Sea Surface Temperature analysis aims at providing daily gap-free maps of sea surface temperature, referred as L4 product, at 0.02deg. x 0.02deg. horizontal resolution, using satellite data from infra-red and microwave radiometers. Uses SST nighttime satellite products from these sensors: NOAA AVHRR, Metop AVHRR, Terra MODIS, Aqua MODIS, Aqua AMSR-E, Envisat AATSR, MSG Seviri"
+id: "baltic_sst_nrt_l4"
+doi: "http://doi.org/10.48670/moi-00155"
+provenance:
+  providers:
+    - name: "DMI"
+      roles: ["producer"]
+    - name: "Copernicus Marine Services"
+      roles: ["licensor", "processor"]
+      url: "https://data.marine.copernicus.eu/product/SST_BAL_SST_L4_NRT_OBSERVATIONS_010_007_b/description"
+  license: "Copernicus Marine Service Commitments and Licence"
+recipes:
+  - id: "SST_BAL_SST_L4_NRT_OBSERVATIONS_010_007_b"
+    object: "recipe:recipe"
+    store_kwargs:
+      store_name: "baltic_sst_nrt_l4.zarr"
+      attrs: {"processed_by": "pangeo-forge"}

--- a/examples/new-feedstock/recipe.py
+++ b/examples/new-feedstock/recipe.py
@@ -1,0 +1,45 @@
+import apache_beam as beam
+import pandas as pd
+
+from pangeo_forge_recipes.patterns import ConcatDim, FilePattern, FileType
+from pangeo_forge_recipes.transforms import (
+    ConsolidateDimensionCoordinates,
+    ConsolidateMetadata,
+    OpenURLWithFSSpec,
+    OpenWithXarray,
+    StoreToZarr,
+)
+
+dates = pd.date_range("2022-02-01", freq="D", periods=28)
+
+URL_FORMAT = "/".join(
+    [
+        "s3://mdl-native-06/native/SST_BAL_SST_L4_NRT_OBSERVATIONS_010_007_b",
+        "DMI-BALTIC-SST-L4-NRT-OBS_FULL_TIME_SERIE/{time:%Y}/{time:%m}",
+        "{time:%Y%m%d%H%M%S}-DMI-L4_GHRSST-SSTfnd-DMI_OI-NSEABALTIC-v02.0-fv01.0.nc",
+    ]
+)
+storage_options = {"endpoint_url": "https://s3.waw3-1.cloudferro.com", "anon": True}
+
+
+def make_url(time):
+    return URL_FORMAT.format(time=time)
+
+
+def recipe(pipeline, *, target_root, store_kwargs):
+    time_concat_dim = ConcatDim("time", dates)
+    pattern = FilePattern(make_url, time_concat_dim)
+
+    return (
+        pipeline
+        | beam.Create(pattern.items())
+        | OpenURLWithFSSpec(open_kwargs=storage_options)
+        | OpenWithXarray(file_type=FileType.netcdf3)
+        | StoreToZarr(
+            combine_dims=pattern.combine_dim_keys,
+            target_root=target_root,
+            **store_kwargs,
+        )
+        | ConsolidateDimensionCoordinates()
+        | ConsolidateMetadata()
+    )

--- a/local.yaml
+++ b/local.yaml
@@ -1,0 +1,4 @@
+storage:
+  target_root: "./recipe_output"
+runner:
+  type: "Direct"

--- a/pangeo_forge_recipes/__main__.py
+++ b/pangeo_forge_recipes/__main__.py
@@ -1,0 +1,4 @@
+from . import cli
+
+if __name__ == "__main__":
+    cli.main()

--- a/pangeo_forge_recipes/__main__.py
+++ b/pangeo_forge_recipes/__main__.py
@@ -1,4 +1,4 @@
-from . import cli
+from .cli.main import main
 
 if __name__ == "__main__":
-    cli.main()
+    main()

--- a/pangeo_forge_recipes/cli.py
+++ b/pangeo_forge_recipes/cli.py
@@ -1,6 +1,0 @@
-import rich_click as click
-
-
-@click.command()
-def main():
-    pass

--- a/pangeo_forge_recipes/cli.py
+++ b/pangeo_forge_recipes/cli.py
@@ -1,0 +1,6 @@
+import rich_click as click
+
+
+@click.command()
+def main():
+    pass

--- a/pangeo_forge_recipes/cli/init.py
+++ b/pangeo_forge_recipes/cli/init.py
@@ -1,0 +1,13 @@
+def initialize_recipe(root, name):
+    # tasks:
+    # - create directory at path
+    # - create git repo
+    # - add gitignore
+    # - add readme
+    # - create "feedstock" dir
+    # - add basic recipe.py
+    # - add basic meta.yaml
+    # - add required deps
+    # - commit
+    # additionally, allow specifying multiple recipes by ID
+    pass

--- a/pangeo_forge_recipes/cli/main.py
+++ b/pangeo_forge_recipes/cli/main.py
@@ -1,0 +1,54 @@
+import pathlib
+
+import rich_click as click
+import yaml
+
+from .init import initialize_recipe
+from .run import run_recipe
+
+click.rich_click.SHOW_ARGUMENTS = True
+
+
+@click.group()
+def main():
+    pass
+
+
+@main.command(help="create a new recipe in PATH")
+@click.argument(
+    "path", type=click.Path(path_type=pathlib.Path, exists=False, writable=True, file_okay=False)
+)
+def init(path):
+    initialize_recipe(path)
+
+
+@main.command(help="run the recipe in PATH")
+@click.option(
+    "-f",
+    "--function-name",
+    "func_name",
+    default="recipe",
+    type=str,
+    help="The name of the recipe function.",
+)
+@click.option(
+    "--runtime-config",
+    type=click.File("r"),
+    required=True,
+    help="runtime configuration. Must be in yaml format.",
+)
+@click.argument(
+    "path",
+    type=click.Path(
+        path_type=pathlib.Path,
+        exists=True,
+        readable=True,
+        writable=False,
+        file_okay=False,
+        dir_okay=True,
+    ),
+)
+def run(path, func_name, runtime_config):
+    config = yaml.safe_load(runtime_config)
+
+    run_recipe(path, func_name, config)

--- a/pangeo_forge_recipes/cli/main.py
+++ b/pangeo_forge_recipes/cli/main.py
@@ -22,15 +22,7 @@ def init(path):
     initialize_recipe(path)
 
 
-@main.command(help="run the recipe in PATH")
-@click.option(
-    "-f",
-    "--function-name",
-    "func_name",
-    default="recipe",
-    type=str,
-    help="The name of the recipe function.",
-)
+@main.command(help="run the feedstock in PATH")
 @click.option(
     "--runtime-config",
     type=click.File("r"),
@@ -43,12 +35,11 @@ def init(path):
         path_type=pathlib.Path,
         exists=True,
         readable=True,
-        writable=False,
         file_okay=False,
         dir_okay=True,
     ),
 )
-def run(path, func_name, runtime_config):
+def run(path, runtime_config):
     config = yaml.safe_load(runtime_config)
 
-    run_recipe(path, func_name, config)
+    run_recipe(path, config)

--- a/pangeo_forge_recipes/cli/run.py
+++ b/pangeo_forge_recipes/cli/run.py
@@ -1,0 +1,8 @@
+def run_recipe(path, func_name, config):
+    # steps:
+    # - import recipe
+    # - extract recipe function
+    # - create runner according to `config`
+    # - create pipeline
+    # - call func with pipeline additional parameters from `config`
+    pass

--- a/pangeo_forge_recipes/cli/run.py
+++ b/pangeo_forge_recipes/cli/run.py
@@ -1,8 +1,56 @@
-def run_recipe(path, func_name, config):
+import importlib.util
+
+import apache_beam as beam
+import yaml
+
+
+def extract_runner_options(config):
+    return config["runner"]
+
+
+def extract_storage_options(config):
+    return config["storage"]
+
+
+def configure_target_root(target_root, meta):
+    return f"{target_root}/{meta['id']}"
+
+
+def load_recipe(name, root):
+    path = root.joinpath(name).with_suffix(".py")
+    spec = importlib.util.spec_from_file_location(name, str(path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    return module
+
+
+def create_runner(options):
+    # force default runner for now
+    return None
+
+
+def run_recipe(path, runtime_config):
     # steps:
     # - import recipe
     # - extract recipe function
     # - create runner according to `config`
     # - create pipeline
     # - call func with pipeline additional parameters from `config`
-    pass
+    meta = yaml.safe_load(path.joinpath("meta.yaml").read_text())
+
+    runner_options = extract_runner_options(runtime_config)
+    storage_options = extract_storage_options(runtime_config)
+
+    for recipe_spec in meta["recipes"]:
+        recipe_name, func_name = recipe_spec["object"].split(":")
+        store_kwargs = recipe_spec.get("store_kwargs", {})
+
+        recipe_module = load_recipe(recipe_name, path)
+        recipe_func = getattr(recipe_module, func_name)
+
+        target_root = configure_target_root(storage_options["target_root"], meta)
+
+        runner = create_runner(runner_options)
+        with beam.Pipeline(runner=runner) as p:
+            recipe_func(p, target_root=target_root, store_kwargs=store_kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ line-length = 100
 
 [tool.isort]
 known_first_party = "pangeo_forge_recipes"
-known_third_party = ["aiohttp", "apache_beam", "cftime", "click", "dask", "fsspec", "gcsfs", "kerchunk", "numpy", "packaging", "pandas", "pytest", "pytest_lazyfixture", "s3fs", "xarray", "zarr"]
+known_third_party = ["aiohttp", "apache_beam", "cftime", "click", "dask", "fsspec", "gcsfs", "kerchunk", "numpy", "packaging", "pandas", "pytest", "pytest_lazyfixture", "rich_click", "s3fs", "xarray", "zarr"]
 multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,12 +72,16 @@ exclude = ["docs_src"]
 [tool.setuptools.package-data]
 pangeo_forge_recipes = ["py.typed"]
 
+[[tool.mypy.overrides]]
+ignore_missing_imports = true
+module = ["yaml.*"]
+
 [tool.black]
 line-length = 100
 
 [tool.isort]
 known_first_party = "pangeo_forge_recipes"
-known_third_party = ["aiohttp", "apache_beam", "cftime", "click", "dask", "fsspec", "gcsfs", "kerchunk", "numpy", "packaging", "pandas", "pytest", "pytest_lazyfixture", "rich_click", "s3fs", "xarray", "zarr"]
+known_third_party = ["aiohttp", "apache_beam", "cftime", "click", "dask", "fsspec", "gcsfs", "kerchunk", "numpy", "packaging", "pandas", "pytest", "pytest_lazyfixture", "rich_click", "s3fs", "xarray", "yaml", "zarr"]
 multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0


### PR DESCRIPTION
Currently there is one official way to run recipes: `pangeo-forge-runner`. As this is pretty hard to use (lots of magic and issues like the one pangeo-forge/pangeo-forge-runner#168 is trying to solve), the ad-hoc way of running recipes appears to be to execute recipe files as scripts, which is not ideal because it couples infrastructure and transformation code.

To work around this, I've tried to sketch out a cli that:
- requires recipes to be functions that take the pipeline as a parameter
- instantiates the runner and pipeline from a runtime config file
- allows passing additional runtime parameters to the function

@norlandrhagen, this is the draft I showed you during the meeting this week.